### PR TITLE
implemented escapeLike() for PostgreSQL driver

### DIFF
--- a/dibi/drivers/postgre.php
+++ b/dibi/drivers/postgre.php
@@ -319,7 +319,14 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 	 */
 	public function escapeLike($value, $pos)
 	{
-		throw new NotImplementedException;
+		if ($this->escMethod) {
+			$value = pg_escape_string($this->connection, $value);
+		} else {
+			$value = pg_escape_string($value);
+		}
+		
+		$value = strtr($value, array( '%' => '\\\\%', '_' => '\\\\_'));
+		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
 	}
 
 


### PR DESCRIPTION
Tested with PostgreSQL 7.4, 8.0, 8.2, 8.3, 9.0
