### PR TITLE
Metoda escapeLike() pro Oracle

### DIFF
--- a/dibi/drivers/oracle.php
+++ b/dibi/drivers/oracle.php
@@ -269,7 +269,9 @@ class DibiOracleDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 	 */
 	public function escapeLike($value, $pos)
 	{
-		throw new NotImplementedException;
+          $value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\\%_");
+          $value = str_replace("'", "''", $value);
+          return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
 	}
 
 


### PR DESCRIPTION
Implementována metoda escapeLike() pro Oracle driver.
