### PR TITLE
Fixed NettePanel output for multiple connections

### DIFF
--- a/dibi/libs/DibiConnection.php
+++ b/dibi/libs/DibiConnection.php
@@ -44,6 +44,12 @@ class DibiConnection extends DibiObject
 	/** @var DibiHashMap Substitutes for identifiers */
 	private $substitutes;
 
+	/** @var int  Elapsed time for all queries */
+	public $totalTime = 0;
+
+	/** @var int  Number or queries */
+	public $numOfQueries = 0;
+
 
 
 	/**
@@ -339,6 +345,7 @@ class DibiConnection extends DibiObject
 		$this->connected || $this->connect();
 
 		$event = $this->onEvent ? new DibiEvent($this, DibiEvent::QUERY, $sql) : NULL;
+		$this->numOfQueries++;
 		dibi::$numOfQueries++;
 		dibi::$sql = $sql;
 		try {

--- a/dibi/libs/DibiEvent.php
+++ b/dibi/libs/DibiEvent.php
@@ -96,6 +96,7 @@ class DibiEvent
 		$this->time += microtime(TRUE);
 		dibi::$elapsedTime = $this->time;
 		dibi::$totalTime += $this->time;
+		$this->connection->totalTime += $this->time;
 		return $this;
 	}
 


### PR DESCRIPTION
When using Nette and dibi with multiple connections it does display the appropriate number of panels in the Debugger panel, each with the appropriate list of queries. However due to the fact that dibi stores the total number of queries and the total time statically, they all display the same overall numbers.

This simple patch solves this bug by introducing two attributes to DibiConnection that count the number of queries and the total time for each connection separately. These numbers are then used in DibiNettePanel.
