### PR TITLE
Fix DibiMsSql2005Driver::getResultColumns()

### DIFF
--- a/dibi/drivers/mssql2005.php
+++ b/dibi/drivers/mssql2005.php
@@ -376,7 +376,7 @@ class DibiMsSql2005Driver extends DibiObject implements IDibiDriver, IDibiResult
 	public function getResultColumns()
 	{
 		$columns = array();
-		foreach ((array) sqlsrv_field_metadata($this->resultSet) AS $fieldMetadata) {
+		foreach ((array) sqlsrv_field_metadata($this->resultSet) as $fieldMetadata) {
 			$columns[] = array(
 				'name' => $fieldMetadata['Name'],
 				'fullname' => $fieldMetadata['Name'],


### PR DESCRIPTION
`sqlsrv_field_metadata()` očekává pouze jeden parametr.

Diskuze: http://forum.dibiphp.com/cs/1274-chybka-v-mssql2005-driveru-fatal-error-v-getresultcolumns
