### PR TITLE
Fix datetime escaping in the Sqlite and Oracle driver

### DIFF
--- a/dibi/drivers/oracle.php
+++ b/dibi/drivers/oracle.php
@@ -250,10 +250,10 @@ class DibiOracleDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 			return $value ? 1 : 0;
 
 		case dibi::DATE:
-			return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value), dibi::TEXT);
 
 		case dibi::DATETIME:
-			return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value), dibi::TEXT);
 
 		default:
 			throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/sqlite.php
+++ b/dibi/drivers/sqlite.php
@@ -257,10 +257,10 @@ class DibiSqliteDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 			return $value ? 1 : 0;
 
 		case dibi::DATE:
-			return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value), dibi::TEXT);
 
 		case dibi::DATETIME:
-			return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value), dibi::TEXT);
 
 		default:
 			throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/sqlite3.php
+++ b/dibi/drivers/sqlite3.php
@@ -252,10 +252,10 @@ class DibiSqlite3Driver extends DibiObject implements IDibiDriver, IDibiResultDr
 			return $value ? 1 : 0;
 
 		case dibi::DATE:
-			return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value), dibi::TEXT);
 
 		case dibi::DATETIME:
-			return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+			return $this->escape($value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value), dibi::TEXT);
 
 		default:
 			throw new InvalidArgumentException('Unsupported type.');


### PR DESCRIPTION
Kvůli SQL injection jsem nepřidal pouze apostrofy, ale celý výstup prohnal přes `escape(..., dibi::TEXT)`.

Fórum (http://forum.dibiphp.com/cs/1276-oracle-neuvozovkovani-pri-pouziti-formatdate#p4880)
