### PR TITLE
DibiFirePhpLogger: Fix undefined property access

### DIFF
--- a/dibi/libs/DibiFirePhpLogger.php
+++ b/dibi/libs/DibiFirePhpLogger.php
@@ -31,6 +31,9 @@ class DibiFirePhpLogger extends DibiObject
 	/** @var int  Elapsed time for all queries */
 	public $totalTime = 0;
 
+	/** @var int  Number of all queries */
+	public $numOfQueries = 0;
+
 	/** @var array */
 	private static $fireTable = array(array('Time', 'SQL Statement', 'Rows', 'Connection'));
 
@@ -64,10 +67,11 @@ class DibiFirePhpLogger extends DibiObject
 		}
 
 		$this->totalTime += $event->time;
+		$this->numOfQueries++;
 		self::$fireTable[] = array(
 			sprintf('%0.3f', $event->time * 1000),
 			strlen($event->sql) > self::$maxLength ? substr($event->sql, 0, self::$maxLength) . '...' : $event->sql,
-			$event->result instanceof Exception ? 'ERROR' : $event->count,
+			$event->result instanceof Exception ? 'ERROR' : (string) $event->count,
 			$event->connection->getConfig('driver') . '/' . $event->connection->getConfig('name')
 		);
 
@@ -78,7 +82,7 @@ class DibiFirePhpLogger extends DibiObject
 		$payload = json_encode(array(
 			array(
 				'Type' => 'TABLE',
-				'Label' => 'dibi profiler (' . count($this->events) . ' SQL queries took ' . sprintf('%0.3f', $this->totalTime * 1000) . ' ms)',
+				'Label' => 'dibi profiler (' . $this->numOfQueries . ' SQL queries took ' . sprintf('%0.3f', $this->totalTime * 1000) . ' ms)',
 			),
 			self::$fireTable,
 		));


### PR DESCRIPTION
Pokud `(string) $event->count` byl integer, sloupec se mi ve FirePHP konzoli nezobrazil.
