### PR TITLE
MySQL & MySQLi: vlastní nastavení časového pásma

### DIFF
--- a/dibi/drivers/mysql.php
+++ b/dibi/drivers/mysql.php
@@ -80,6 +80,7 @@ class DibiMySqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 			// default values
 			DibiConnection::alias($config, 'flags', 'options');
 			if (!isset($config['charset'])) $config['charset'] = 'utf8';
+			if (!isset($config['timezone'])) $config['timezone'] = date('P');
 			if (!isset($config['username'])) $config['username'] = ini_get('mysql.default_user');
 			if (!isset($config['password'])) $config['password'] = ini_get('mysql.default_password');
 			if (!isset($config['host'])) {
@@ -131,7 +132,9 @@ class DibiMySqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 			$this->query("SET sql_mode='$config[sqlmode]'");
 		}
 
-		$this->query("SET time_zone='" . date('P') . "'");
+		if (isset($config['timezone'])) {
+			$this->query("SET time_zone='$config[timezone]'");
+		}
 
 		$this->buffered = empty($config['unbuffered']);
 	}

--- a/dibi/drivers/mysqli.php
+++ b/dibi/drivers/mysqli.php
@@ -81,6 +81,7 @@ class DibiMySqliDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 		} else {
 			// default values
 			if (!isset($config['charset'])) $config['charset'] = 'utf8';
+			if (!isset($config['timezone'])) $config['timezone'] = date('P');
 			if (!isset($config['username'])) $config['username'] = ini_get('mysqli.default_user');
 			if (!isset($config['password'])) $config['password'] = ini_get('mysqli.default_pw');
 			if (!isset($config['socket'])) $config['socket'] = ini_get('mysqli.default_socket');
@@ -132,7 +133,9 @@ class DibiMySqliDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 			$this->query("SET sql_mode='$config[sqlmode]'");
 		}
 
-		$this->query("SET time_zone='" . date('P') . "'");
+		if (isset($config['timezone'])) {
+			$this->query("SET time_zone='$config[timezone]'");
+		}
 
 		$this->buffered = empty($config['unbuffered']);
 	}


### PR DESCRIPTION
Vynucené nastavení časového pásma podle PHP trpí v našich luzích a hájích zásadní chybou při operacích s datem, který je v odlišném čase - zimním a letním. V dibi se momentálně jako timezone nastaví vždy string `+01:00` (`+02:00` v létě), což přebije výchozí hodnotu - obvykle `CET`/`CEST`, která si umí s letním a zimním časem poradit.

Patch přidává driverům volitelný parametr `timezone`. S nainstalovanými TZ daty na MySQL serveru mu lze předat hodnoty jako _Europe/Prague_ nebo _America/Los_Angeles_, jinak stačí hodnota _SYSTEM_.

Thread na fóru: http://forum.dibiphp.com/cs/959-timezone-v-mysql#p3859
