### PR TITLE
Throw entire callstack for interbase-based databases.

### DIFF
--- a/dibi/drivers/firebird.php
+++ b/dibi/drivers/firebird.php
@@ -390,7 +390,7 @@ class DibiFirebirdDriver extends DibiObject implements IDibiDriver, IDibiResultD
 
 		if (DibiDriverException::catchError($msg)) {
 			if (ibase_errcode() == self::ERROR_EXCEPTION_THROWN) {
-				preg_match('/exception (\d+) (\w+) (.*)/i', ibase_errmsg(), $match);
+				preg_match('/exception (\d+) (\w+) (.*)/is', ibase_errmsg(), $match);
 				throw new DibiProcedureException($match[3], $match[1], $match[2], dibi::$sql);
 
 			} else {


### PR DESCRIPTION
Errors thrown by firebird are multiline, exceptions get thrown from inside the logic. (.*) matches everything up until first line by default - this mitigates the problem and matches the entire rest of the string (= including multilines).

Original result is the first line (deepest from stack).

Steps to reproduce: create trigger -> call function -> call function that throws exception
