### PR TITLE
Renamed extend class 

### DIFF
--- a/dibi/Nette/DibiNetteExtension.php
+++ b/dibi/Nette/DibiNetteExtension.php
@@ -18,7 +18,7 @@
  * @package    dibi\nette
  * @phpversion 5.3
  */
-class DibiNetteExtension extends Nette\Config\CompilerExtension
+class DibiNetteExtension extends Nette\DI\CompilerExtension
 {
 
 	public function loadConfiguration()


### PR DESCRIPTION
Rename extend class Nette\Config\CompilerExtension to Nette\DI\CompilerExtension.

In new version of Nette was this class renamed.
