### PR TITLE
Fixed detecting "point" type

### DIFF
--- a/dibi/libs/DibiDatabaseInfo.php
+++ b/dibi/libs/DibiDatabaseInfo.php
@@ -622,7 +622,7 @@ class DibiColumnInfo extends DibiObject
 			'^_' => dibi::TEXT, // PostgreSQL arrays
 			'BYTEA|BLOB|BIN' => dibi::BINARY,
 			'TEXT|CHAR' => dibi::TEXT,
-			'YEAR|BYTE|COUNTER|SERIAL|INT|LONG' => dibi::INTEGER,
+			'YEAR|BYTE|COUNTER|SERIAL|^INT|LONG' => dibi::INTEGER,
 			'CURRENCY|REAL|MONEY|FLOAT|DOUBLE|DECIMAL|NUMERIC|NUMBER' => dibi::FLOAT,
 			'^TIME$' => dibi::TIME,
 			'TIME' => dibi::DATETIME, // DATETIME, TIMESTAMP


### PR DESCRIPTION
PostgreSQL's point type is detected as integer and thus always returns 0.
