### PR TITLE
DibiResult: fixed normalization of time when begins by 00:

### DIFF
--- a/dibi/libs/DibiResult.php
+++ b/dibi/libs/DibiResult.php
@@ -524,7 +524,7 @@ class DibiResult extends DibiObject implements IDataSource
 				$row[$key] = ((bool) $value) && $value !== 'f' && $value !== 'F';
 
 			} elseif ($type === dibi::DATE || $type === dibi::DATETIME) {
-				if ((int) $value === 0) { // '', NULL, FALSE, '0000-00-00', ...
+				if ((int) $value === 0 && substr((string) $value, 0, 3) !== '00:') { // '', NULL, FALSE, '0000-00-00', ...
 
 				} elseif (empty($this->formats[$type])) { // return DateTime object (default)
 					$row[$key] = new DibiDateTime(is_numeric($value) ? date('Y-m-d H:i:s', $value) : $value);


### PR DESCRIPTION
Without such fix, times which begin by `00:` are left as string, they are not converted to DateTime as expected.

http://forum.dibiphp.com/cs/1352-automaticka-detekce-sloupce-time#p5177

Maybe normalized value would be always DateTime, NULL or integer.
