### PR TITLE
Use DateTime instead of date()

### DIFF
--- a/dibi/dibi.php
+++ b/dibi/dibi.php
@@ -480,6 +480,7 @@ class dibi
 
 	/**
 	 * @return DibiDateTime
+	 * @deprecated
 	 */
 	public static function datetime($time = NULL)
 	{

--- a/dibi/drivers/DibiFirebirdDriver.php
+++ b/dibi/drivers/DibiFirebirdDriver.php
@@ -281,10 +281,14 @@ class DibiFirebirdDriver extends DibiObject implements IDibiDriver, IDibiResultD
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMsSql2005Driver.php
+++ b/dibi/drivers/DibiMsSql2005Driver.php
@@ -237,10 +237,14 @@ class DibiMsSql2005Driver extends DibiObject implements IDibiDriver, IDibiResult
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMsSqlDriver.php
+++ b/dibi/drivers/DibiMsSqlDriver.php
@@ -222,10 +222,14 @@ class DibiMsSqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMySqlDriver.php
+++ b/dibi/drivers/DibiMySqlDriver.php
@@ -316,10 +316,14 @@ class DibiMySqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMySqliDriver.php
+++ b/dibi/drivers/DibiMySqliDriver.php
@@ -304,10 +304,14 @@ class DibiMySqliDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiOdbcDriver.php
+++ b/dibi/drivers/DibiOdbcDriver.php
@@ -245,10 +245,14 @@ class DibiOdbcDriver extends DibiObject implements IDibiDriver, IDibiResultDrive
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("#m/d/Y#") : date("#m/d/Y#", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("#m/d/Y#");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("#m/d/Y H:i:s#") : date("#m/d/Y H:i:s#", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("#m/d/Y H:i:s#");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiOracleDriver.php
+++ b/dibi/drivers/DibiOracleDriver.php
@@ -239,10 +239,14 @@ class DibiOracleDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDate);
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDateTime);
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -282,10 +282,14 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 				return $this->connection->quote($value, PDO::PARAM_BOOL);
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiPostgreDriver.php
+++ b/dibi/drivers/DibiPostgreDriver.php
@@ -297,10 +297,14 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 				return $value ? 'TRUE' : 'FALSE';
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format("'Y-m-d'") : date("'Y-m-d'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d'");
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format("'Y-m-d H:i:s'") : date("'Y-m-d H:i:s'", $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format("'Y-m-d H:i:s'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiSqlite3Driver.php
+++ b/dibi/drivers/DibiSqlite3Driver.php
@@ -238,10 +238,14 @@ class DibiSqlite3Driver extends DibiObject implements IDibiDriver, IDibiResultDr
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDate);
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDateTime);
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiSqliteDriver.php
+++ b/dibi/drivers/DibiSqliteDriver.php
@@ -243,10 +243,14 @@ class DibiSqliteDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 				return $value ? 1 : 0;
 
 			case dibi::DATE:
-				return $value instanceof DateTime ? $value->format($this->fmtDate) : date($this->fmtDate, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDate);
 
 			case dibi::DATETIME:
-				return $value instanceof DateTime ? $value->format($this->fmtDateTime) : date($this->fmtDateTime, $value);
+				if (! $value instanceof DateTime)
+					$value = new DibiDateTime($value);
+				return $value->format($this->fmtDateTime);
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/libs/DibiDateTime.php
+++ b/dibi/libs/DibiDateTime.php
@@ -22,7 +22,7 @@ class DibiDateTime extends DateTime
 	public function __construct($time = 'now', DateTimeZone $timezone = NULL)
 	{
 		if (is_numeric($time)) {
-			$time = date('Y-m-d H:i:s', $time);
+			$time = "@".$time;
 		}
 		if ($timezone === NULL) {
 			parent::__construct($time);
@@ -68,7 +68,7 @@ class DibiDateTime extends DateTime
 
 	public function setTimestamp($timestamp)
 	{
-		return $this->__construct(date('Y-m-d H:i:s', $timestamp), new DateTimeZone($this->getTimezone()->getName())); // getTimeZone() crashes in PHP 5.2.6
+		return $this->__construct("@".$timestamp, new DateTimeZone($this->getTimezone()->getName())); // getTimeZone() crashes in PHP 5.2.6
 	}
 
 

--- a/dibi/libs/DibiResult.php
+++ b/dibi/libs/DibiResult.php
@@ -527,13 +527,7 @@ class DibiResult extends DibiObject implements IDataSource
 				if ((int) $value === 0 && substr((string) $value, 0, 3) !== '00:') { // '', NULL, FALSE, '0000-00-00', ...
 
 				} elseif (empty($this->formats[$type])) { // return DateTime object (default)
-					$row[$key] = new DibiDateTime(is_numeric($value) ? date('Y-m-d H:i:s', $value) : $value);
-
-				} elseif ($this->formats[$type] === 'U') { // return timestamp
-					$row[$key] = is_numeric($value) ? (int) $value : strtotime($value);
-
-				} elseif (is_numeric($value)) { // formatted date
-					$row[$key] = date($this->formats[$type], $value);
+					$row[$key] = new DibiDateTime($value);
 
 				} else {
 					$value = new DibiDateTime($value);

--- a/dibi/libs/DibiRow.php
+++ b/dibi/libs/DibiRow.php
@@ -46,7 +46,7 @@ class DibiRow implements ArrayAccess, IteratorAggregate, Countable
 			if ((int) $time === 0) { // '', NULL, FALSE, '0000-00-00', ...
 				return NULL;
 			}
-			$time = new DibiDateTime(is_numeric($time) ? date('Y-m-d H:i:s', $time) : $time);
+			$time = new DibiDateTime($time);
 		}
 		return $format === NULL ? $time : $time->format($format);
 	}
@@ -61,9 +61,10 @@ class DibiRow implements ArrayAccess, IteratorAggregate, Countable
 	{
 		trigger_error(__METHOD__ . '() is deprecated.', E_USER_WARNING);
 		$time = $this[$key];
-		return (int) $time === 0 // '', NULL, FALSE, '0000-00-00', ...
-			? NULL
-			: (is_numeric($time) ? (int) $time : strtotime($time));
+		if ((int) $time === 0) // '', NULL, FALSE, '0000-00-00', ...
+			return NULL;
+		$time = new DibiDateTime($time);
+		return $time->format('U');
 	}
 
 


### PR DESCRIPTION
On 32bits systems, date() is affected bug the 2038 bug
DateTime always uses 64bits representation

Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
