### PR TITLE
composer.json: fix compatibility with dg/dibi requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
 	"require-dev": {
 		"nette/tester": "@dev"
 	},
+	"replace": {
+		"dg/dibi": "self.version"
+	},
 	"autoload": {
 		"classmap": ["dibi/"]
 	}


### PR DESCRIPTION
This fixes compatibility which you have broken in 326376159f62e70c85b182a3d8e17b3f4588dbab. Now when you depend on two libraries and one of them depends on `dg/dibi` and the other one on `dibi/dibi`, only `dibi/dibi` will be installed.

Note: This should be tagged 2.1.1.
