### PR TITLE
Fix fatal error, when using custom error handling when not ignoring deprecated messages.

### DIFF
--- a/dibi/dibi.php
+++ b/dibi/dibi.php
@@ -17,8 +17,14 @@ if (version_compare(PHP_VERSION, '5.2.0', '<')) {
 	throw new Exception('dibi needs PHP 5.2.0 or newer.');
 }
 
-@set_magic_quotes_runtime(FALSE); // intentionally @
-
+if (version_compare(PHP_VERSION, '5.3.0', '<'))
+{
+    @set_magic_quotes_runtime(FALSE); // intentionally @
+}
+else
+{
+    ini_set('magic_quotes_runtime', 0);
+}
 
 require_once dirname(__FILE__) . '/libs/interfaces.php';
 require_once dirname(__FILE__) . '/libs/DibiDateTime.php';


### PR DESCRIPTION
My error handler threw exceptions on deprecated messages. I changed that, but want to suggest the following change nonetheless; it may be beneficial to anyone using >= php 5.3.
I also wonder if it is "dibi's responsibility" to set magic_quotes_runtime? It is nice and all, but if it is set to true, an exception could be thrown?
