### PR TITLE
Ability to execute SQL for trigger definitions in DibiConnection::loadFile without SQL errors

### DIFF
--- a/dibi/libs/DibiConnection.php
+++ b/dibi/libs/DibiConnection.php
@@ -646,13 +646,28 @@ class DibiConnection extends DibiObject
 
 		$count = 0;
 		$sql = '';
+		$delimitedSql = NULL;
 		while (!feof($handle)) {
 			$s = fgets($handle);
-			$sql .= $s;
-			if (substr(rtrim($s), -1) === ';') {
-				$this->driver->query($sql);
-				$sql = '';
-				$count++;
+			if (strpos($s, 'DELIMITER') === 0) {
+				if (is_null($delimitedSql)) {
+					$delimitedSql = '';
+				} else {
+					$this->driver->query($delimitedSql);
+					$delimitedSql = NULL;
+				}
+				continue;
+			}
+
+			if (!is_null($delimitedSql)) {
+				$delimitedSql .= $s;
+			} else {
+				$sql .= $s;
+				if (substr(rtrim($s), -1) === ';') {
+					$this->driver->query($sql);
+					$sql = '';
+					$count++;
+				}
 			}
 		}
 		if (trim($sql) !== '') {


### PR DESCRIPTION
For example, if you have trigger in myslqdump’s generated SQL file, it might look similar to this:

``` sql
DELIMITER ;;
    /*!50003 CREATE*/ /*!50017 */ /*!50003 TRIGGER `after_insert_table_a`
    AFTER INSERT ON `table_a` FOR EACH ROW
        BEGIN
            UPDATE `table_b` SET
            `column_a` = 0
            WHERE `column_b` = 0 AND `id` = NEW.`table_b_id`; 
        END */;;
DELIMITER ;
```

When loading file with such part, you get some kind of `You have an error in your SQL syntax` exception.

Change in attached commit takes anything between `DELIMITER` statements and executes it at once which works fine ([mentioned in dibi forum](http://forum.dibiphp.com/cs/914-feature-request-loadfile-a-nepovinny-paramater-delimiter)).
