### PR TITLE
Avoid error handler invocation

### DIFF
--- a/dibi/dibi.php
+++ b/dibi/dibi.php
@@ -14,8 +14,9 @@ if (version_compare(PHP_VERSION, '5.2.0', '<')) {
 	throw new Exception('dibi needs PHP 5.2.0 or newer.');
 }
 
-@set_magic_quotes_runtime(FALSE); // intentionally @
-
+if (get_magic_quotes_runtime()) {
+	set_magic_quotes_runtime(FALSE);
+}
 
 require_once dirname(__FILE__) . '/libs/interfaces.php';
 require_once dirname(__FILE__) . '/libs/DibiDateTime.php';

--- a/dibi/drivers/DibiMySqliDriver.php
+++ b/dibi/drivers/DibiMySqliDriver.php
@@ -458,7 +458,7 @@ class DibiMySqliDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 	public function getResultResource()
 	{
 		$this->autoFree = FALSE;
-		return @$this->resultSet->type === NULL ? NULL : $this->resultSet;
+		return $this->resultSet === NULL || $this->resultSet->type === NULL ? NULL : $this->resultSet;
 	}
 
 }


### PR DESCRIPTION
Would it be possible to avoid error handler invocation by replacing code with @? It complicates our error handling.
