### PR TITLE
Add aposthrophes back to dates

### DIFF
--- a/dibi/drivers/DibiFirebirdDriver.php
+++ b/dibi/drivers/DibiFirebirdDriver.php
@@ -281,7 +281,7 @@ class DibiFirebirdDriver extends DibiObject implements IDibiDriver, IDibiResultD
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMsSql2005Driver.php
+++ b/dibi/drivers/DibiMsSql2005Driver.php
@@ -237,7 +237,7 @@ class DibiMsSql2005Driver extends DibiObject implements IDibiDriver, IDibiResult
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMsSqlDriver.php
+++ b/dibi/drivers/DibiMsSqlDriver.php
@@ -222,7 +222,7 @@ class DibiMsSqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMySqlDriver.php
+++ b/dibi/drivers/DibiMySqlDriver.php
@@ -316,7 +316,7 @@ class DibiMySqlDriver extends DibiObject implements IDibiDriver, IDibiResultDriv
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiMySqliDriver.php
+++ b/dibi/drivers/DibiMySqliDriver.php
@@ -304,7 +304,7 @@ class DibiMySqliDriver extends DibiObject implements IDibiDriver, IDibiResultDri
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -282,7 +282,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');

--- a/dibi/drivers/DibiPostgreDriver.php
+++ b/dibi/drivers/DibiPostgreDriver.php
@@ -297,7 +297,7 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 				if (!$value instanceof DateTime) {
 					$value = new DibiDateTime($value);
 				}
-				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "Y-m-d");
+				return $value->format($type === dibi::DATETIME ? "'Y-m-d H:i:s'" : "'Y-m-d'");
 
 			default:
 				throw new InvalidArgumentException('Unsupported type.');


### PR DESCRIPTION
Commit 7318658017 removed apostrophes from dates and that caused
dibi to build different queries. Compare:
...WHERE `date_created` < '2014-02-21';
vs.
...WHERE `date_created` < 2014-02-21;
