### PR TITLE
DibiDateTime: Restored php 5.2 support.

### DIFF
--- a/dibi/libs/DibiDateTime.php
+++ b/dibi/libs/DibiDateTime.php
@@ -44,7 +44,7 @@ class DibiDateTime extends DateTime
 
 	public function setTimestamp($timestamp)
 	{
-		$zone = PHP_VERSION_ID === 50206 ? new \DateTimeZone($this->getTimezone()->getName()) : $this->getTimezone();
+		$zone = PHP_VERSION_ID === 50206 ? new DateTimeZone($this->getTimezone()->getName()) : $this->getTimezone();
 		$this->__construct('@' . $timestamp);
 		$this->setTimeZone($zone);
 		return $this;


### PR DESCRIPTION
Removed global-namespace backslash to restore php 5.2 support. Bug introduced in commit ddf7b74bf0054c3baae38b3fff8183e3df8f2ce1.
