### PR TITLE
PostgreSQL: fixed identifier escaping in reflection.

### DIFF
--- a/dibi/drivers/DibiPostgreDriver.php
+++ b/dibi/drivers/DibiPostgreDriver.php
@@ -476,7 +476,7 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 	 */
 	public function getColumns($table)
 	{
-		$_table = $this->escape($table, dibi::TEXT);
+		$_table = $this->escape($this->escape($table, dibi::IDENTIFIER), dibi::TEXT);
 		$res = $this->query("
 			SELECT indkey
 			FROM pg_class
@@ -543,7 +543,7 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 	 */
 	public function getIndexes($table)
 	{
-		$_table = $this->escape($table, dibi::TEXT);
+		$_table = $this->escape($this->escape($table, dibi::IDENTIFIER), dibi::TEXT);
 		$res = $this->query("
 			SELECT
 				a.attnum AS ordinal_position,
@@ -591,7 +591,7 @@ class DibiPostgreDriver extends DibiObject implements IDibiDriver, IDibiResultDr
 	 */
 	public function getForeignKeys($table)
 	{
-		$_table = $this->escape($table, dibi::TEXT);
+		$_table = $this->escape($this->escape($table, dibi::IDENTIFIER), dibi::TEXT);
 
 		$res = $this->query("
 			SELECT


### PR DESCRIPTION
Fixed identifier quoting in reflection, brought up by @milo in #140.
