### PR TITLE
DibiTranslator: respect %if blocks for %lmt and %ofs as well

### DIFF
--- a/dibi/libs/DibiTranslator.php
+++ b/dibi/libs/DibiTranslator.php
@@ -543,14 +543,27 @@ final class DibiTranslator extends DibiObject
 
 			} elseif ($mod === 'lmt') { // apply limit
 				if ($this->args[$cursor] !== NULL) {
-					$this->limit = (int) $this->args[$cursor];
+					if (! $this->comment) {
+						$this->limit = (int) $this->args[$cursor];
+					} else {
+						// the limit should be mentioned in the comment
+						// however it's impossible to generate valid commented-out sql
+						// for Mysql, Postgres & SQLite, driver->applyLimit would work here
+						// but for others not so much
+						return sprintf('(limit %d)', (int) $this->args[$cursor]);
+					}
 				}
 				$cursor++;
 				return '';
 
 			} elseif ($mod === 'ofs') { // apply offset
 				if ($this->args[$cursor] !== NULL) {
-					$this->offset = (int) $this->args[$cursor];
+					if (! $this->comment) {
+						$this->offset = (int) $this->args[$cursor];
+					} else {
+						// see the comment on limit above, applies to offset as well
+						return sprintf('(offset %d)', (int) $this->args[$cursor]);
+					}
 				}
 				$cursor++;
 				return '';


### PR DESCRIPTION
Fixes issue #87.

In current dibi, something like 

    \dibi::query([
        'SELECT * FROM foo',
        '%if', false,
            '%lmt', 3,
            '%ofs', 5,
        '%end',
    ]);

yields `SELECT * FROM foo /* */ LIMIT 3 OFFSET 5`, which is probably not what you want.

This changes the translation of `%lmt` and `%ofs` to only set `->limit` and `->offset` when `->comment` is falsy.

The new behaviour is to generate `SELECT * FROM foo /* (limit 3) ... (offset 5) */`.
I would have preferred to generate proper SQL, but it would have been possible only with the MySQL*, Postgres and SQLite* drivers. The other drivers' `applyLimit` changes the whole SQL statement and thus would generate horrible stuff.

Thus, while I feel it's necessary to mention the limit/offset in the comment (because debugability), I think we should not pretend to generate valid SQL by making it `/* LIMIT 3 OFFSET 5 */` because since we can't make it valid always, we should be explicit about it not being valid.

But feel free to change it, obviously :).