### PR TITLE
Optimizations for sites with hundreds of SQL queries

### DIFF
--- a/dibi/libs/DibiFirePhpLogger.php
+++ b/dibi/libs/DibiFirePhpLogger.php
@@ -61,6 +61,11 @@ class DibiFirePhpLogger extends DibiObject
 			return;
 		}
 
+		if (!$this->numOfQueries) {
+			header('X-Wf-Protocol-dibi: http://meta.wildfirehq.org/Protocol/JsonStream/0.2');
+			header('X-Wf-dibi-Plugin-1: http://meta.firephp.org/Wildfire/Plugin/FirePHP/Library-FirePHPCore/0.2.0');
+			header('X-Wf-dibi-Structure-1: http://meta.firephp.org/Wildfire/Structure/FirePHP/FirebugConsole/0.1');
+		}
 		$this->totalTime += $event->time;
 		$this->numOfQueries++;
 		self::$fireTable[] = array(
@@ -69,10 +74,6 @@ class DibiFirePhpLogger extends DibiObject
 			$event->result instanceof Exception ? 'ERROR' : (string) $event->count,
 			$event->connection->getConfig('driver') . '/' . $event->connection->getConfig('name')
 		);
-
-		header('X-Wf-Protocol-dibi: http://meta.wildfirehq.org/Protocol/JsonStream/0.2');
-		header('X-Wf-dibi-Plugin-1: http://meta.firephp.org/Wildfire/Plugin/FirePHP/Library-FirePHPCore/0.2.0');
-		header('X-Wf-dibi-Structure-1: http://meta.firephp.org/Wildfire/Structure/FirePHP/FirebugConsole/0.1');
 
 		$payload = json_encode(array(
 			array(

--- a/dibi/libs/DibiFirePhpLogger.php
+++ b/dibi/libs/DibiFirePhpLogger.php
@@ -20,6 +20,9 @@ class DibiFirePhpLogger extends DibiObject
 	/** maximum SQL length */
 	static public $maxLength = 1000;
 
+	/** size of json stream chunk */
+	static public $jsonStreamChunkSize = 4990;
+	
 	/** @var int */
 	public $filter;
 
@@ -78,7 +81,7 @@ class DibiFirePhpLogger extends DibiObject
 			),
 			self::$fireTable,
 		));
-		foreach (str_split($payload, 4990) as $num => $s) {
+		foreach (str_split($payload, self::$jsonStreamChunkSize) as $num => $s) {
 			$num++;
 			header("X-Wf-dibi-1-1-d$num: |$s|\\"); // protocol-, structure-, plugin-, message-index
 		}


### PR DESCRIPTION
I keep getting following error in Firebug (2.0.4) and FirePHP (0.7.4):

> "There was a problem writ...ePHP/FirebugConsole/0.1", SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data

This error shows up, when there is more than one chunk of json stream created. I actually do not know how to fix json stream, but I have found, that even payload of size 100kB can be sent in one chunk and Firefox displays it just fine. So I suggest to let user specify the length of the chunk.

Additionally I think, that saving some CPU cycles, by setting constant headers only once may be a good idea. However, compared to the payload being json_encoded for each SQL statement this does not seem like noticable improvement.