### PR TITLE
Oracle does not support any brackets around table name

### DIFF
--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -255,6 +255,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 					case 'mysql':
 						return '`' . str_replace('`', '``', $value) . '`';
 
+					case 'oci':
 					case 'pgsql':
 						return '"' . str_replace('"', '""', $value) . '"';
 
@@ -263,7 +264,6 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 						return '[' . strtr($value, '[]', '  ') . ']';
 
 					case 'odbc':
-					case 'oci': // TODO: not tested
 					case 'mssql':
 						return '[' . str_replace(array('[', ']'), array('[[', ']]'), $value) . ']';
 


### PR DESCRIPTION
I want to use Dibi PDO driver for communication with oracle database.

I have used following code

``` php
$config = array(
    'dsn' => 'oci:dbname=//server.domain:1521/database',
    'username' => 'username',
    'password' => 'password',
);
$pdo = new PDO($config['dsn'], $config['username'], $config['password']);
$pdo->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);

$db_config = array(
    'driver' => 'pdo',
    'resource' => $pdo,
    'lazy' => TRUE,
);

$connection = new DibiConnection($db_config);
$query = $connection->select('*')->from('table')->where('column = %s', 'value');
var_dump($query->fetch());
```

But this failed with exception "OCIStmtExecute: ORA-00903: invalid table name", but table with this name really exists.

Output of plain sql contain bug:

``` php
echo $query->__toString();
```

Result:

``` sql
SELECT * FROM ( SELECT * FROM [table] WHERE column = 'value') WHERE ROWNUM <= 1
```

Oracle does not support square brackets around table name.
Expected query is:

``` sql
SELECT * FROM ( SELECT * FROM table WHERE column = 'value') WHERE ROWNUM <= 1
```
