### PR TITLE
MSSQL: Adds limit support for PDO dblib driver on unix

### DIFF
--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -359,6 +359,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 				break;
 
 			case 'odbc':
+			case 'dblib':
 			case 'mssql':
 			case 'sqlsrv':
 				if ($offset < 1) {


### PR DESCRIPTION
When using freetds exposed as PDO dblib driver on linux, any attempt to call fetch crashes on `PDO or driver does not support applying limit or offset.`. 

This patch applies existing sqlsrv/mssql driver limit statement also to dblib driver.
