### PR TITLE
Dibi: type TIME is now handled as TEXT instead of DATETIME (BC break).

### DIFF
--- a/dibi/libs/Dibi.php
+++ b/dibi/libs/Dibi.php
@@ -23,7 +23,7 @@ class dibi
 		FLOAT = 'f',
 		DATE = 'd',
 		DATETIME = 't',
-		TIME = 't';
+		TIME = 's';
 
 	const IDENTIFIER = 'n',
 		AFFECTED_ROWS = 'a';


### PR DESCRIPTION
TIME values will no longer be normalized to DibiDateTime objects, as that raises an Exception for values of more than 24 hours. For example: 
`DateTime::__construct(): Failed to parse time string (78:38:48) at position 0 (7): Unexpected character.`
Such value is valid at least on MySQL.

This is a BC break for anyone who relied on getting a DateTime object with values of less then 24 hours.
Once php 5.2 support is dropped, we should consider using DateInterval to handle TIME values instead.