### PR TITLE
DibiPdoDriver: fallback to the config version

### DIFF
--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -78,7 +78,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 		}
 
 		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
-		$this->serverVersion = $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
+		$this->serverVersion = isset($config['version']) ? $config['version'] : @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION); // intentionally @
 	}
 
 


### PR DESCRIPTION
If driver do not support ATTR_SERVER_VERSION (like dblib) fallback to the version from config, or set null as we do not know what is the driver version.

I belive this is better solution then add some creazy switch with queries for all possible versions on all drivers, and becouse it is faster to pass variable then run query asking about version.

This closes #170 