### PR TITLE
DibiPdoDriver::escape() added support for dblib

### DIFF
--- a/dibi/drivers/DibiPdoDriver.php
+++ b/dibi/drivers/DibiPdoDriver.php
@@ -272,6 +272,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 					case 'mssql':
 						return '[' . str_replace(array('[', ']'), array('[[', ']]'), $value) . ']';
 
+					case 'dblib':
 					case 'sqlsrv':
 						return '[' . str_replace(']', ']]', $value) . ']';
 
@@ -334,6 +335,7 @@ class DibiPdoDriver extends DibiObject implements IDibiDriver, IDibiResultDriver
 
 			case 'odbc':
 			case 'mssql':
+			case 'dblib':
 			case 'sqlsrv':
 				$value = strtr($value, array("'" => "''", '%' => '[%]', '_' => '[_]', '[' => '[[]'));
 				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");


### PR DESCRIPTION
Fixed escaping for linux version of mssql driver - dblib.