### PR TITLE
Support for named arguments in queries.

### DIFF
--- a/dibi/dibi.php
+++ b/dibi/dibi.php
@@ -33,3 +33,4 @@ require_once dirname(__FILE__) . '/libs/DibiDatabaseInfo.php';
 require_once dirname(__FILE__) . '/libs/DibiEvent.php';
 require_once dirname(__FILE__) . '/libs/DibiFileLogger.php';
 require_once dirname(__FILE__) . '/libs/DibiFirePhpLogger.php';
+require_once dirname(__FILE__) . '/libs/DibiArguments.php';

--- a/dibi/libs/DibiArguments.php
+++ b/dibi/libs/DibiArguments.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of the "dibi" - smart database abstraction layer.
+ */
+
+
+/**
+ * dibi argument collection implementation.
+ *
+ * @author     Jakub Macek
+ * @package    dibi
+ */
+class DibiArguments extends ArrayObject implements IDibiArguments
+{
+}

--- a/dibi/libs/DibiTranslator.php
+++ b/dibi/libs/DibiTranslator.php
@@ -123,12 +123,12 @@ final class DibiTranslator extends DibiObject
 						(\')((?:\'\'|[^\'])*)\'|     ## 3,4) 'string'
 						(")((?:""|[^"])*)"|          ## 5,6) "string"
 						(\'|")|                      ## 7) lone quote
-						:(?:(\S*?:)([a-zA-Z0-9._]?)|([a-zA-Z0-9_]+)(?:%([a-zA-Z~][a-zA-Z0-9~]{0,5}))?)|    ## 8,9) :substitution:   10,11) :namedArgument%modifier  or :namedArgument
+						:(?:([a-zA-Z0-9_]*?:)([a-zA-Z0-9._]?)|([a-zA-Z0-9_]+)(?:%([a-zA-Z~][a-zA-Z0-9~]{0,5}))?)|    ## 8,9) :substitution:   10,11) :namedArgument%modifier  or :namedArgument
 						%([a-zA-Z~][a-zA-Z0-9~]{0,5})|## 12) modifier
 						(\?)                         ## 13) placeholder
 					)/xs',
 */                  // note: this can change $this->args & $this->cursor & ...
-					. preg_replace_callback('/(?=[`[\'":%?])(?:`(.+?)`|\[(.+?)\]|(\')((?:\'\'|[^\'])*)\'|(")((?:""|[^"])*)"|(\'|")|:(?:(\S*?:)([a-zA-Z0-9._]?)|([a-zA-Z0-9_]+)(?:%([a-zA-Z~][a-zA-Z0-9~]{0,5}))?)|%([a-zA-Z~][a-zA-Z0-9~]{0,5})|(\?))/s',
+					. preg_replace_callback('/(?=[`[\'":%?])(?:`(.+?)`|\[(.+?)\]|(\')((?:\'\'|[^\'])*)\'|(")((?:""|[^"])*)"|(\'|")|:(?:([a-zA-Z0-9_]*?:)([a-zA-Z0-9._]?)|([a-zA-Z0-9_]+)(?:%([a-zA-Z~][a-zA-Z0-9~]{0,5}))?)|%([a-zA-Z~][a-zA-Z0-9~]{0,5})|(\?))/s',
 							array($this, 'cb'),
 							substr($arg, $toSkip)
 					);
@@ -415,7 +415,7 @@ final class DibiTranslator extends DibiObject
 					if (strlen($value) !== $toSkip) {
 						$value = substr($value, 0, $toSkip)
 						. preg_replace_callback(
-							'/(?=[`[\'":])(?:`(.+?)`|\[(.+?)\]|(\')((?:\'\'|[^\'])*)\'|(")((?:""|[^"])*)"|(\'|")|:(\S*?:)([a-zA-Z0-9._]?))/s',
+							'/(?=[`[\'":%?])(?:`(.+?)`|\[(.+?)\]|(\')((?:\'\'|[^\'])*)\'|(")((?:""|[^"])*)"|(\'|")|:(?:([a-zA-Z0-9_]*?:)([a-zA-Z0-9._]?)|([a-zA-Z0-9_]+)(?:%([a-zA-Z~][a-zA-Z0-9~]{0,5}))?)|%([a-zA-Z~][a-zA-Z0-9~]{0,5})|(\?))/s',
 							array($this, 'cb'),
 							substr($value, $toSkip)
 						);

--- a/dibi/libs/interfaces.php
+++ b/dibi/libs/interfaces.php
@@ -218,3 +218,14 @@ interface IDibiReflector
 	function getForeignKeys($table);
 
 }
+
+
+/**
+ * dibi named argument collection.
+ *
+ * @author     Jakub Macek
+ * @package    dibi
+ */
+interface IDibiArguments extends ArrayAccess
+{
+}

--- a/examples/query-language-named-arguments.php
+++ b/examples/query-language-named-arguments.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html><link rel="stylesheet" href="data/style.css">
+
+<h1>Query Language Named Arguments Examples | dibi</h1>
+
+<?php
+
+require __DIR__ . '/../dibi/dibi.php';
+
+date_default_timezone_set('Europe/Prague');
+
+
+dibi::connect(array(
+    'driver' => 'sqlite3',
+    'database' => 'data/sample.s3db',
+));
+dibi::getConnection()->getSubstitutes()->test = 'test_';
+dibi::getConnection()->getSubstitutes()->{''} = 'testtoo_';
+
+// SELECT
+$name = 'K%';
+$timestamp = mktime(0, 0, 0, 10, 13, 1997);
+$id_list = array(1, 2, 3);
+
+// If the argument implements IDibiArguments, it is removed from the arguments
+// and added to the named argument collections.
+// If the %nmd modifier is used for a positional argument, it is also added
+// to the named argument collections. It should be an array or object implementing
+// the ArrayAccess interface.
+// Any named argument is a colon with identifier with optional percent sign and
+// value modifier.
+// Original substitutions are still present.
+
+dibi::test('
+	SELECT COUNT(*) as [count]
+	%nmd
+	FROM [:test:customers]
+	WHERE [name] LIKE :name
+	AND [added] > :timestamp%d
+	OR [customer_id] IN :id_list%in
+	ORDER BY [name]'
+, new ArrayObject(['timestamp' => new DibiDateTime($timestamp)])
+, new DibiArguments(['name' => $name, 'id_list' => $id_list]));

--- a/examples/query-language-named-arguments.php
+++ b/examples/query-language-named-arguments.php
@@ -10,8 +10,8 @@ date_default_timezone_set('Europe/Prague');
 
 
 dibi::connect(array(
-    'driver' => 'sqlite3',
-    'database' => 'data/sample.s3db',
+	'driver' => 'sqlite3',
+	'database' => 'data/sample.s3db',
 ));
 dibi::getConnection()->getSubstitutes()->test = 'test_';
 dibi::getConnection()->getSubstitutes()->{''} = 'testtoo_';


### PR DESCRIPTION
I've added support for named arguments in queries, hopefully in a way that is going to be both familiar to PDO users and in the spirit of Dibi.

The change is mostly in DibiTranslator - change to the regexp and callback function. You can supply mulltiple collections of arguments either directly as objects implementing IDibiArguments or using modifier %nmd on a positional argument (similar approach to %lmt).

Example is provided.
