### PR TITLE
Allow disconnecting when passing PDO instance.

### DIFF
--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -67,7 +67,7 @@ class PdoDriver implements Dibi\Driver, Dibi\ResultDriver
 
 		if ($config['resource'] instanceof PDO) {
 			$this->connection = $config['resource'];
-
+			unset($config['resource'], $config['pdo']);
 		} else {
 			try {
 				$this->connection = new PDO($config['dsn'], $config['username'], $config['password'], $config['options']);


### PR DESCRIPTION
PDO instance is disconnected when there is no other reference to the instance remaining. However when PDO instance is passed to the driver using `$config['pdo']` or `$config['resource']`, it remains in the config array. And then, the disconnect() does not work as intended.

NOT freeing the PDO instance from config prevents the disconnection using the `disconnect()` method.