### PR TITLE
SqlsrvDriver: fixed: sql server does not respond on non-string password

### DIFF
--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -72,12 +72,17 @@ class SqlsrvDriver implements Dibi\Driver, Dibi\ResultDriver
 			$this->connection = $config['resource'];
 
 		} else {
-			// Default values
-			if (!isset($config['options']['CharacterSet'])) {
-				$config['options']['CharacterSet'] = 'UTF-8';
-			}
+			$options = & $config['options'];
 
-			$this->connection = sqlsrv_connect($config['host'], (array) $config['options']);
+			// Default values
+			if (!isset($options['CharacterSet'])) {
+				$options['CharacterSet'] = 'UTF-8';
+			}
+			$options['PWD'] = (string) $options['PWD'];
+			$options['UID'] = (string) $options['UID'];
+			$options['Database'] = (string) $options['Database'];
+
+			$this->connection = sqlsrv_connect($config['host'], $options);
 		}
 
 		if (!is_resource($this->connection)) {


### PR DESCRIPTION
When connection to sql server (version 2012) using 

```yaml
  db:
    host: 'url\instance'
    driver: sqlsrv
    database: dbname
    username: username
    password: 123456
```

then sql server wont respond, because password is an integer and not a string. This PR fixes this type conversion.