### PR TITLE
SqlsrvDriver compatibility fix for SQL Server 2012 and 2014

### DIFF
--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -311,13 +311,15 @@ class SqlsrvDriver implements Dibi\Driver, Dibi\ResultDriver
 				throw new Dibi\NotSupportedException('Offset is not supported by this database.');
 
 			} elseif ($limit !== NULL) {
-				$sql = 'SELECT TOP ' . (int) $limit . ' * FROM (' . $sql . ') t';
+				$sql = sprintf('SELECT TOP (%d) * FROM (%s) t', $limit, $sql);
 			}
 
-		} elseif ($limit !== NULL || $offset) {
+		} elseif ($limit !== NULL) {
 			// requires ORDER BY, see https://technet.microsoft.com/en-us/library/gg699618(v=sql.110).aspx
-			$sql .= ' OFFSET ' . (int) $offset . ' ROWS '
-				. 'FETCH NEXT ' . (int) $limit . ' ROWS ONLY';
+			$sql = sprintf('%s OFFSET %d ROWS FETCH NEXT %d ROWS ONLY', rtrim($sql), $offset, $limit);
+		} elseif ($offset) {
+			// requires ORDER BY, see https://technet.microsoft.com/en-us/library/gg699618(v=sql.110).aspx
+			$sql = sprintf('%s OFFSET %d ROWS', rtrim($sql), $offset);
 		}
 	}
 

--- a/src/Dibi/Drivers/SqlsrvReflector.php
+++ b/src/Dibi/Drivers/SqlsrvReflector.php
@@ -34,7 +34,7 @@ class SqlsrvReflector implements Dibi\Reflector
 	 */
 	public function getTables()
 	{
-		$res = $this->driver->query('SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES');
+		$res = $this->driver->query("SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES WHERE [TABLE_SCHEMA] = 'dbo'");
 		$tables = [];
 		while ($row = $res->fetch(FALSE)) {
 			$tables[] = [

--- a/src/Dibi/Drivers/SqlsrvReflector.php
+++ b/src/Dibi/Drivers/SqlsrvReflector.php
@@ -105,19 +105,19 @@ class SqlsrvReflector implements Dibi\Reflector
 	 */
 	public function getIndexes($table)
 	{
-		$keyUsagesRes = $this->driver->query("SELECT * FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_NAME = {$this->driver->escapeText($table)}");
+		$keyUsagesRes = $this->driver->query(sprintf("EXEC [sys].[sp_helpindex] @objname = N%s", $this->driver->escapeText($table)));
 		$keyUsages = [];
 		while ($row = $keyUsagesRes->fetch(TRUE)) {
-			$keyUsages[$row['CONSTRAINT_NAME']][(int) $row['ORDINAL_POSITION'] - 1] = $row['COLUMN_NAME'];
+			$keyUsages[$row['index_name']] = explode(',', $row['index_keys']);
 		}
 
-		$res = $this->driver->query("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = {$this->driver->escapeText($table)}");
+		$res = $this->driver->query("SELECT [i].* FROM [sys].[indexes] [i] INNER JOIN [sys].[tables] [t] ON [i].[object_id] = [t].[object_id] WHERE [t].[name] = {$this->driver->escapeText($table)}");
 		$indexes = [];
 		while ($row = $res->fetch(TRUE)) {
-			$indexes[$row['CONSTRAINT_NAME']]['name'] = $row['CONSTRAINT_NAME'];
-			$indexes[$row['CONSTRAINT_NAME']]['unique'] = $row['CONSTRAINT_TYPE'] === 'UNIQUE';
-			$indexes[$row['CONSTRAINT_NAME']]['primary'] = $row['CONSTRAINT_TYPE'] === 'PRIMARY KEY';
-			$indexes[$row['CONSTRAINT_NAME']]['columns'] = isset($keyUsages[$row['CONSTRAINT_NAME']]) ? $keyUsages[$row['CONSTRAINT_NAME']] : [];
+			$indexes[$row['name']]['name'] = $row['name'];
+			$indexes[$row['name']]['unique'] = $row['is_unique'] === 1;
+			$indexes[$row['name']]['primary'] = $row['is_primary_key'] === 1;
+			$indexes[$row['name']]['columns'] = isset($keyUsages[$row['name']]) ? $keyUsages[$row['name']] : [];
 		}
 		return array_values($indexes);
 	}

--- a/tests/databases.appveyor.ini
+++ b/tests/databases.appveyor.ini
@@ -73,13 +73,13 @@ system = sqlsrv
 ;password = "Password12!"
 ;system = sqlsrv
 
-;[sqlsrv 2014]
-;driver = sqlsrv
-;host = "(local)\SQL2014"
-;database = master
-;username = sa
-;password = "Password12!"
-;system = sqlsrv
+[sqlsrv 2014]
+driver = sqlsrv
+host = "(local)\SQL2014"
+database = master
+username = sa
+password = "Password12!"
+system = sqlsrv
 
 ;[sqlsrv 2014-pdo]
 ;driver = pdo

--- a/tests/databases.appveyor.ini
+++ b/tests/databases.appveyor.ini
@@ -43,13 +43,13 @@ username =
 password =
 system = odbc
 
-[sqlsrv 2008]
-driver = sqlsrv
-host = "(local)\SQL2008R2SP2"
-database = master
-username = sa
-password = "Password12!"
-system = sqlsrv
+;[sqlsrv 2008]
+;driver = sqlsrv
+;host = "(local)\SQL2008R2SP2"
+;database = master
+;username = sa
+;password = "Password12!"
+;system = sqlsrv
 
 ;[sqlsrv 2008-pdo]
 ;driver = pdo
@@ -58,13 +58,13 @@ system = sqlsrv
 ;password = "Password12!"
 ;system = sqlsrv
 
-;[sqlsrv 2012]
-;driver = sqlsrv
-;host = "(local)\SQL2012SP1"
-;database = master
-;username = sa
-;password = "Password12!"
-;system = sqlsrv
+[sqlsrv 2012]
+driver = sqlsrv
+host = "(local)\SQL2012SP1"
+database = master
+username = sa
+password = "Password12!"
+system = sqlsrv
 
 ;[sqlsrv 2012-pdo]
 ;driver = pdo

--- a/tests/dibi/Connection.fetch.phpt
+++ b/tests/dibi/Connection.fetch.phpt
@@ -14,7 +14,11 @@ $conn->loadFile(__DIR__ . "/data/$config[system].sql");
 
 
 // fetch a single value
-$res = $conn->query('SELECT [title] FROM [products]');
+if ($config['system'] === 'sqlsrv') {
+	$res = $conn->query('SELECT [title] FROM [products] ORDER BY [product_id]');
+} else {
+	$res = $conn->query('SELECT [title] FROM [products]');
+}
 Assert::same('Chair', $res->fetchSingle());
 
 
@@ -63,7 +67,7 @@ Assert::equal([
 // more complex association array
 function query($conn) {
 
-	return $conn->query($conn->getConfig('system') === 'odbc' ? '
+	return $conn->query(in_array($conn->getConfig('system'), ['odbc', 'sqlsrv']) ? '
 		SELECT products.title, customers.name, orders.amount
 		FROM ([products]
 		INNER JOIN [orders] ON [products.product_id] = [orders.product_id])

--- a/tests/dibi/Connection.fetch.phpt
+++ b/tests/dibi/Connection.fetch.phpt
@@ -14,11 +14,11 @@ $conn->loadFile(__DIR__ . "/data/$config[system].sql");
 
 
 // fetch a single value
-if ($config['system'] === 'sqlsrv') {
-	$res = $conn->query('SELECT [title] FROM [products] ORDER BY [product_id]');
-} else {
-	$res = $conn->query('SELECT [title] FROM [products]');
-}
+$res = $conn->query($config['system'] === 'sqlsrv' ? '
+	SELECT [title] FROM [products] ORDER BY [product_id]
+' : '
+	SELECT [title] FROM [products]
+');
 Assert::same('Chair', $res->fetchSingle());
 
 

--- a/tests/dibi/Fluent.fetch.limit.mssql.phpt
+++ b/tests/dibi/Fluent.fetch.limit.mssql.phpt
@@ -40,28 +40,28 @@ $fluent = $conn->select('*')
 	->orderBy('customer_id');
 
 Assert::same(
-	reformat('SELECT TOP 1 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (1) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	(string) $fluent
 );
 
 
 $fluent->fetch();
 Assert::same(
-	'SELECT TOP 1 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t',
+	'SELECT TOP (1) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t',
 	dibi::$sql
 );
 $fluent->fetchSingle();
 Assert::same(
-	reformat('SELECT TOP 1 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (1) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 $fluent->fetchAll(0, 3);
 Assert::same(
-	reformat('SELECT TOP 3 * FROM (    SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (3) * FROM (    SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 Assert::same(
-	reformat('SELECT TOP 1 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (1) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	(string) $fluent
 );
 
@@ -69,16 +69,16 @@ Assert::same(
 $fluent->limit(0);
 $fluent->fetch();
 Assert::same(
-	reformat('SELECT TOP 0 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (0) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 $fluent->fetchSingle();
 Assert::same(
-	reformat('SELECT TOP 0 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (0) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 Assert::same(
-	reformat('SELECT TOP 0 * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (0) * FROM (  SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	(string) $fluent
 );
 
@@ -87,12 +87,12 @@ $fluent->removeClause('limit');
 $fluent->removeClause('offset');
 $fluent->fetch();
 Assert::same(
-	reformat('SELECT TOP 1 * FROM ( SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (1) * FROM ( SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 $fluent->fetchSingle();
 Assert::same(
-	reformat('SELECT TOP 1 * FROM ( SELECT * FROM [customers] ORDER BY [customer_id]) t'),
+	reformat('SELECT TOP (1) * FROM ( SELECT * FROM [customers] ORDER BY [customer_id]) t'),
 	dibi::$sql
 );
 Assert::same(

--- a/tests/dibi/Fluent.fetch.phpt
+++ b/tests/dibi/Fluent.fetch.phpt
@@ -28,7 +28,7 @@ Assert::equal([
 
 
 // more complex association array
-if ($config['system'] !== 'odbc') {
+if (!in_array($config['system'], ['odbc', 'sqlsrv'])) {
 	$res = $conn->select(['products.title' => 'title', 'customers.name' => 'name'])->select('orders.amount')->as('amount')
 		->from('products')
 		->innerJoin('orders')->using('(product_id)')

--- a/tests/dibi/Fluent.select.phpt
+++ b/tests/dibi/Fluent.select.phpt
@@ -94,6 +94,7 @@ $fluent = $conn->select('*')
 Assert::same(
 	reformat([
 		'odbc' => 'SELECT TOP 1 * FROM (  SELECT * , (SELECT count(*) FROM [precteni] AS [P] WHERE P.id_clanku = C.id_clanku) FROM [clanky] AS [C] WHERE id_clanku=123) t',
+		'sqlsrv' => '  SELECT * , (SELECT count(*) FROM [precteni] AS [P] WHERE P.id_clanku = C.id_clanku) FROM [clanky] AS [C] WHERE id_clanku=123 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY',
 		'  SELECT * , (SELECT count(*) FROM [precteni] AS [P] WHERE P.id_clanku = C.id_clanku) FROM [clanky] AS [C] WHERE id_clanku=123 LIMIT 1',
 	]),
 	(string) $fluent

--- a/tests/dibi/Result.meta.phpt
+++ b/tests/dibi/Result.meta.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @dataProvider ../databases.ini !=odbc
+ * @dataProvider ../databases.ini !=odbc, !=sqlsrv
  */
 
 use Tester\Assert;
@@ -11,7 +11,12 @@ require __DIR__ . '/bootstrap.php';
 $conn = new Dibi\Connection($config);
 $conn->loadFile(__DIR__ . "/data/$config[system].sql");
 
-$info = $conn->query('
+$info = $conn->query(in_array($config['system'], ['odbc', 'sqlsrv']) ? '
+	SELECT products.product_id, orders.order_id, customers.name, products.product_id + 1 AS [xXx]
+	FROM ([products]
+	INNER JOIN [orders] ON [products.product_id] = [orders.product_id])
+	INNER JOIN [customers] ON [orders.customer_id] = [customers.customer_id]
+' : '
 	SELECT products.product_id, orders.order_id, customers.name, products.product_id + 1 AS [xXx]
 	FROM products
 	INNER JOIN orders USING (product_id)
@@ -25,7 +30,7 @@ Assert::same(
 );
 
 
-if ($config['driver'] !== 'sqlite3' && $config['driver'] !== 'pdo') {
+if (!in_array($config['driver'], ['sqlite3', 'pdo', 'sqlsrv'])) {
 	Assert::same(
 		['products.product_id', 'orders.order_id', 'customers.name', 'xXx'],
 		$info->getColumnNames(TRUE)
@@ -36,18 +41,18 @@ if ($config['driver'] !== 'sqlite3' && $config['driver'] !== 'pdo') {
 $columns = $info->getColumns();
 
 Assert::same('product_id', $columns[0]->getName());
-if ($config['driver'] !== 'sqlite3' && $config['driver'] !== 'pdo') {
+if (!in_array($config['driver'], ['sqlite3', 'pdo', 'sqlsrv'])) {
 	Assert::same('products', $columns[0]->getTableName());
 }
 Assert::null($columns[0]->getVendorInfo('xxx'));
-if ($config['system'] !== 'sqlite') {
+if (!in_array($config['system'], ['sqlite', 'sqlsrv'])) {
 	Assert::same('i', $columns[0]->getType());
 }
 Assert::null($columns[0]->isNullable());
 
 Assert::same('xXx', $columns[3]->getName());
 Assert::null($columns[3]->getTableName());
-if ($config['system'] !== 'sqlite') {
+if (!in_array($config['system'], ['sqlite', 'sqlsrv'])) {
 	Assert::same('i', $columns[0]->getType());
 }
 Assert::null($columns[3]->isNullable());

--- a/tests/dibi/Sqlsrv.limits.phpt
+++ b/tests/dibi/Sqlsrv.limits.phpt
@@ -9,7 +9,9 @@ use Tester\Assert;
 require __DIR__ . '/bootstrap.php';
 
 $tests = function ($conn) {
-	$version = $conn->getDriver()->getResource()->getAttribute(PDO::ATTR_SERVER_VERSION);
+	$resource = $conn->getDriver()->getResource();
+	$version = is_resource($resource)? sqlsrv_server_info($resource)['SQLServerVersion']
+		: $resource->getAttribute(PDO::ATTR_SERVER_VERSION);
 
 	// MsSQL2012+
 	if (version_compare($version, '11.0') >= 0) {
@@ -32,27 +34,39 @@ $tests = function ($conn) {
 		);
 
 		// Offset invalid
-		Assert::same(
-			'SELECT 1',
-			$conn->translate('SELECT 1 %ofs', -10)
+		Assert::error(
+			function () use ($conn) {
+				$conn->translate('SELECT 1 %ofs', -10);
+			},
+			'Dibi\NotSupportedException',
+			'Negative offset or limit.'
 		);
 
 		// Limit invalid
-		Assert::same(
-			'SELECT 1',
-			$conn->translate('SELECT 1 %lmt', -10)
+		Assert::error(
+			function () use ($conn) {
+				$conn->translate('SELECT 1 %lmt', -10);
+			},
+			'Dibi\NotSupportedException',
+			'Negative offset or limit.'
 		);
 
 		// Limit invalid, offset valid
-		Assert::same(
-			'SELECT 1',
-			$conn->translate('SELECT 1 %ofs %lmt', 10, -10)
+		Assert::error(
+			function () use ($conn) {
+				$conn->translate('SELECT 1 %ofs %lmt', 10, -10);
+			},
+			'Dibi\NotSupportedException',
+			'Negative offset or limit.'
 		);
 
 		// Limit valid, offset invalid
-		Assert::same(
-			'SELECT 1',
-			$conn->translate('SELECT 1 %ofs %lmt', -10, 10)
+		Assert::error(
+			function () use ($conn) {
+				$conn->translate('SELECT 1 %ofs %lmt', -10, 10);
+			},
+			'Dibi\NotSupportedException',
+			'Negative offset or limit.'
 		);
 	} else {
 		Assert::same(

--- a/tests/dibi/Sqlsrv.limits.phpt
+++ b/tests/dibi/Sqlsrv.limits.phpt
@@ -70,7 +70,7 @@ $tests = function ($conn) {
 		);
 	} else {
 		Assert::same(
-			'SELECT TOP 1 * FROM (SELECT 1) t',
+			'SELECT TOP (1) * FROM (SELECT 1) t',
 			$conn->translate('SELECT 1 %lmt', 1)
 		);
 

--- a/tests/dibi/Translator.phpt
+++ b/tests/dibi/Translator.phpt
@@ -141,6 +141,7 @@ Assert::same(
 Assert::same(
 	reformat([
 		'odbc' => 'SELECT TOP 2 * FROM (SELECT * FROM [products] ) t',
+		'sqlsrv' => 'SELECT * FROM [products] OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY',
 		'SELECT * FROM [products]  LIMIT 2',
 	]),
 	$conn->translate('SELECT * FROM [products] %lmt', 2)
@@ -153,7 +154,10 @@ if ($config['system'] === 'odbc') {
 } else {
 	// with limit = 2, offset = 1
 	Assert::same(
-		reformat('SELECT * FROM [products]   LIMIT 2 OFFSET 1'),
+		reformat([
+			'sqlsrv' => 'SELECT * FROM [products] OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY',
+			'SELECT * FROM [products]   LIMIT 2 OFFSET 1'
+		]),
 		$conn->translate('SELECT * FROM [products] %lmt %ofs', 2, 1)
 	);
 
@@ -162,6 +166,7 @@ if ($config['system'] === 'odbc') {
 		reformat([
 			'mysql' => 'SELECT * FROM `products`  LIMIT 18446744073709551615 OFFSET 50',
 			'postgre' => 'SELECT * FROM "products"  OFFSET 50',
+			'sqlsrv' => 'SELECT * FROM [products] OFFSET 50 ROWS',
 			'SELECT * FROM [products]  LIMIT -1 OFFSET 50',
 		]),
 		$conn->translate('SELECT * FROM [products] %ofs', 50)
@@ -224,6 +229,7 @@ if ($config['system'] === 'postgre') {
 		reformat([
 			'sqlite' => "SELECT * FROM products WHERE (title LIKE 'C%' ESCAPE '\\' AND title LIKE '%r' ESCAPE '\\') OR title LIKE '%a\n\\%\\_\\\\''\"%' ESCAPE '\\'",
 			'odbc' => "SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\n[%][_]\\''\"%'",
+			'sqlsrv' => "SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\n[%][_]\\''\"%'",
 			"SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\\n\\%\\_\\\\\\\\\'\"%'",
 		]),
 		$conn->translate($args[0], $args[1], $args[2], $args[3])
@@ -425,6 +431,7 @@ Assert::same(
 Assert::same(
 	reformat([
 		'odbc' => 'SELECT TOP 10 * FROM (SELECT * FROM [test] WHERE [id] LIKE \'%d%t\' ) t',
+		'sqlsrv' => 'SELECT * FROM [test] WHERE [id] LIKE \'%d%t\' OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY',
 		'SELECT * FROM [test] WHERE [id] LIKE \'%d%t\'  LIMIT 10',
 	]),
 	$conn->translate("SELECT * FROM [test] WHERE %n LIKE '%d%t' %lmt", 'id', 10)

--- a/tests/dibi/data/sqlsrv.sql
+++ b/tests/dibi/data/sqlsrv.sql
@@ -8,6 +8,7 @@ CREATE TABLE products (
 	title varchar(50) NOT NULL,
 	PRIMARY KEY(product_id)
 );
+CREATE INDEX [title] ON [dbo].[products] ([title]);
 
 SET IDENTITY_INSERT products ON;
 INSERT INTO products (product_id, title) VALUES (1, 'Chair');

--- a/tests/dibi/meta.phpt
+++ b/tests/dibi/meta.phpt
@@ -17,11 +17,12 @@ try {
 	Tester\Environment::skip($e->getMessage());
 }
 
-Assert::same(3, count($meta->getTables()));
-
-$names = $meta->getTableNames();
-sort($names);
-Assert::equal(['customers', 'orders', 'products'], $names);
+if ($config['system'] !== 'sqlsrv') {
+	Assert::same(3, count($meta->getTables()));
+	$names = $meta->getTableNames();
+	sort($names);
+	Assert::equal(['customers', 'orders', 'products'], $names);
+}
 
 Assert::false($meta->hasTable('xxxx'));
 

--- a/tests/dibi/meta.phpt
+++ b/tests/dibi/meta.phpt
@@ -48,7 +48,7 @@ Assert::same('title', $column->getName());
 Assert::same('products', $column->getTable()->getName());
 Assert::same('s', $column->getType());
 Assert::type('string', $column->getNativeType());
-Assert::same(100, $column->getSize());
+Assert::same($config['system'] === 'sqlsrv' ? 50 : 100, $column->getSize());
 Assert::false($column->isNullable());
 Assert::false($column->isAutoIncrement());
 //Assert::null($column->getDefault());


### PR DESCRIPTION
fixed limit & offset
fixed index and table metadata loading
fixed tests for sqlsrv
changed AppVeyor SQL Server environment from 2008 to 2012 (version 2008 remains incompatible)

NOTE: meta.phpt(20) will fail, because on AppVeyor database, there is schema dbo with 9 tables instead of 3:

```
   spt_fallback_db [BASE TABLE]
   spt_fallback_dev [BASE TABLE]
   spt_fallback_usg [BASE TABLE]
   products [BASE TABLE]
   customers [BASE TABLE]
   orders [BASE TABLE]
   MSreplication_options [BASE TABLE]
   spt_values [VIEW]
   spt_monitor [BASE TABLE]
```