### PR TITLE
Travis CI: removed php-unix.ini from tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - php: hhvm
 
 script:
-    - vendor/bin/tester tests -s -p php -c tests/php-unix.ini
+    - vendor/bin/tester tests -s -p php
     - php temp/code-checker/src/code-checker.php --short-arrays
 
 after_failure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,8 +51,8 @@ install:
     - copy tests\databases.appveyor.ini tests\databases.ini
 
 test_script:
-    - vendor\bin\tester tests -s -p c:\php5\php -c tests\php-win.ini
-    - vendor\bin\tester tests -s -p c:\php7\php -c tests\php-win.ini
+    - vendor\bin\tester tests -s -p c:\php5\php -c tests\php5-win.ini
+    - vendor\bin\tester tests -s -p c:\php7\php -c tests\php7-win.ini
 
 on_failure:
     # Print *.actual content

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,2 +1,0 @@
-[PHP]
-;extension_dir = "./ext"

--- a/tests/php5-win.ini
+++ b/tests/php5-win.ini
@@ -16,4 +16,3 @@ extension=php_pgsql.dll
 extension=php_sqlite3.dll
 extension=php_sqlsrv_ts.dll
 extension=php_pdo_sqlsrv_ts.dll
-extension=php_odbc.dll

--- a/tests/php7-win.ini
+++ b/tests/php7-win.ini
@@ -1,0 +1,17 @@
+[PHP]
+extension_dir = "./ext"
+;extension=php_mssql.dll
+extension=php_mysqli.dll
+;extension=php_oci8.dll
+;extension=php_oci8_11g.dll
+;extension=php_pdo_firebird.dll
+;extension=php_pdo_mssql.dll
+extension=php_pdo_mysql.dll
+;extension=php_pdo_oci.dll
+extension=php_pdo_odbc.dll
+extension=php_pdo_pgsql.dll
+extension=php_pdo_sqlite.dll
+extension=php_pgsql.dll
+extension=php_sqlite3.dll
+extension=php_sqlsrv_ts.dll
+extension=php_odbc.dll


### PR DESCRIPTION
`tests/php-unix.ini` was rmoved in https://github.com/dg/dibi/commit/595791a511838efb2b3247c48401f82d55c9204a but it is required in travis and all tests are failing now.

This PR removes this ini file from Travis tests (or we can restore this ini file back)