### PR TITLE
Disconnect on not connected driver not fail

### DIFF
--- a/src/Dibi/Drivers/MySqlDriver.php
+++ b/src/Dibi/Drivers/MySqlDriver.php
@@ -139,7 +139,7 @@ class MySqlDriver implements Dibi\Driver, Dibi\ResultDriver
 	 */
 	public function disconnect()
 	{
-		mysql_close($this->connection);
+		@mysql_close($this->connection); // @ - connection can be already disconnected
 	}
 
 

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -138,7 +138,7 @@ class MySqliDriver implements Dibi\Driver, Dibi\ResultDriver
 	 */
 	public function disconnect()
 	{
-		mysqli_close($this->connection);
+		@mysqli_close($this->connection); // @ - connection can be already disconnected
 	}
 
 

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -111,7 +111,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 	 */
 	public function disconnect()
 	{
-		pg_close($this->connection);
+		@pg_close($this->connection); // @ - connection can be already disconnected
 	}
 
 

--- a/tests/dibi/Connection.connect.phpt
+++ b/tests/dibi/Connection.connect.phpt
@@ -36,3 +36,15 @@ test(function () use ($config) { // query string
 	Assert::same($config['driver'], $conn->getConfig('driver'));
 	Assert::type('Dibi\Driver', $conn->getDriver());
 });
+
+
+test(function () use ($config) {
+	$conn = new Connection($config);
+	Assert::true($conn->isConnected());
+
+	$conn->disconnect();
+	Assert::false($conn->isConnected());
+
+	$conn->disconnect();
+	Assert::false($conn->isConnected());
+});


### PR DESCRIPTION
Sometimes database go away and Connection::isConnected() is returning TRUE. Prevent this should be posibble to disconnect on closed connection without error.