### PR TITLE
Ignore PHP warning

### DIFF
--- a/src/Dibi/DateTime.php
+++ b/src/Dibi/DateTime.php
@@ -58,13 +58,14 @@ class DateTime extends \DateTime
 
 	public function __wakeup()
 	{
-		if (isset($this->fix)) {
-			if (isset($this->fix[1])) {
-				$this->__construct($this->fix[0], new \DateTimeZone($this->fix[1]));
-			} else {
-				$this->__construct($this->fix[0]);
-			}
+		if (isset($this->fix[1])) {
+			$this->__construct($this->fix[0], new \DateTimeZone($this->fix[1]));
 			unset($this->fix);
+		} elseif (isset($this->fix)) {
+			$this->__construct($this->fix[0]);
+			unset($this->fix);
+		} else {
+			parent::__wakeup();
 		}
 	}
 

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -370,7 +370,7 @@ class FirebirdDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 	 */
 	public function fetch($assoc)
 	{
-		$result = $assoc ? ibase_fetch_assoc($this->resultSet, IBASE_TEXT) : ibase_fetch_row($this->resultSet, IBASE_TEXT); // intentionally @
+		$result = $assoc ? @ibase_fetch_assoc($this->resultSet, IBASE_TEXT) : @ibase_fetch_row($this->resultSet, IBASE_TEXT); // intentionally @
 
 		if (ibase_errcode()) {
 			if (ibase_errcode() == self::ERROR_EXCEPTION_THROWN) {


### PR DESCRIPTION
If fetch have error, PHP show Warning, this is error by my opinion as Dibi Throw Exception with information, so the Warning is useless, and even more, if we catch exception, we still have warning.