### PR TITLE
OracleDriver: Fixed dates escaping

### DIFF
--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -19,8 +19,6 @@ use Dibi;
  *   - password (or pass)
  *   - charset => character encoding to set
  *   - schema => alters session schema
- *   - formatDate => how to format date in SQL (@see date)
- *   - formatDateTime => how to format datetime in SQL (@see date)
  *   - resource (resource) => existing connection resource
  *   - persistent => Creates persistent connections with oci_pconnect instead of oci_new_connect
  *   - lazy, profiler, result, substitutes, ... => see Dibi\Connection options
@@ -40,9 +38,6 @@ class OracleDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 
 	/** @var bool */
 	private $autocommit = TRUE;
-
-	/** @var string  Date and datetime format */
-	private $fmtDate, $fmtDateTime;
 
 	/** @var int|FALSE Number of affected rows */
 	private $affectedRows = FALSE;
@@ -67,8 +62,6 @@ class OracleDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 	public function connect(array & $config)
 	{
 		$foo = & $config['charset'];
-		$this->fmtDate = isset($config['formatDate']) ? $config['formatDate'] : 'U';
-		$this->fmtDateTime = isset($config['formatDateTime']) ? $config['formatDateTime'] : 'U';
 
 		if (isset($config['resource'])) {
 			$this->connection = $config['resource'];
@@ -281,7 +274,7 @@ class OracleDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		if (!$value instanceof \DateTime && !$value instanceof \DateTimeInterface) {
 			$value = new Dibi\DateTime($value);
 		}
-		return $value->format($this->fmtDate);
+		return "to_date('" . $value->format('Y-m-d') . "', 'YYYY-mm-dd')";
 	}
 
 
@@ -290,7 +283,7 @@ class OracleDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		if (!$value instanceof \DateTime && !$value instanceof \DateTimeInterface) {
 			$value = new Dibi\DateTime($value);
 		}
-		return $value->format($this->fmtDateTime);
+		return "to_date('" . $value->format('Y-m-d G:i:s') . "', 'YYYY-mm-dd hh24:mi:ss')";
 	}
 
 


### PR DESCRIPTION
In current state formatting date (%d) or datetimes (%t) in query reproducing malformed sql

**This example:**

``` php
$dibi->select('*')
    ->from('SAMPLE_TABLE')
    ->where('COLUMN_DT = %d', new \DateTime('2016-08-05 12:00:00'));
```

**Will generate this sql:**

``` sql
SELECT * FROM "SAMPLE_TABLE" WHERE COLUMN_DT = 1470391200
```

**which produce error:**

<code>
ORA-00932: inconsistent datatypes: expected DATE got NUMBER
</code>

In oracle, value should be converted into date by to_date() function. Second parameter for this function is optional mask, if its not provided then oracle try guess format by NLS parameters. This patch solving problem in secure way.

[See oracle documentation](http://www.techonthenet.com/oracle/functions/to_date.php)

Result for same fluent as before will be this:

``` sql
SELECT * FROM "SAMPLE_TABLE" WHERE COLUMN_DT = to_date('2016-08-05', 'YYYY-mm-dd')
```

The configuration **fmtDate** and **fmtDateTime** are useless
