### PR TITLE
PostgreSQL: add support for more than one schema in search_path

### DIFF
--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -100,7 +100,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		}
 
 		if (isset($config['schema'])) {
-			$this->query('SET search_path TO "' . $config['schema'] . '"');
+			$this->query('SET search_path TO "' . implode('", "', (array) $config['schema']) . '"');
 		}
 	}
 


### PR DESCRIPTION
Allows set more than one schema to current search_path, by an array of schema names in `$config['schema']` connection parameter.

`SET search_path TO "myschema", "public";`
