### PR TITLE
Result: strict type fix

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -162,8 +162,9 @@ class Result implements IDataSource
 	/**
 	 * Fetches the row at current position, process optional type conversion.
 	 * and moves the internal cursor to the next position
+	 * @return ?Row|array
 	 */
-	final public function fetch(): ?Row
+	final public function fetch()
 	{
 		$row = $this->getResultDriver()->fetch(true);
 		if ($row === null) {

--- a/tests/dibi/Connection.fetch.phpt
+++ b/tests/dibi/Connection.fetch.phpt
@@ -52,6 +52,15 @@ Assert::equal([
 ], iterator_to_array($res));
 
 
+// fetch row by row as array
+$res = $conn->query('SELECT * FROM [products] ORDER BY product_id')->setRowClass(null);
+Assert::equal([
+	['product_id' => num(1), 'title' => 'Chair'],
+	['product_id' => num(2), 'title' => 'Table'],
+	['product_id' => num(3), 'title' => 'Computer'],
+], iterator_to_array($res));
+
+
 // fetch complete result set like association array
 $res = $conn->query('SELECT * FROM [products] ORDER BY product_id');
 Assert::equal([


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

`Result::fetch()` can return `array` for `setRowClass(null)`.