### PR TITLE
Tracy\Panel: fixed TypeError in renderException()

### DIFF
--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -73,6 +73,8 @@ class Panel implements Tracy\IBarPanel
 				'panel' => Helpers::dump($e->getSql(), true),
 			];
 		}
+
+		return null;
 	}
 
 


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Fixing:
```
Error in panel Dibi\Bridges\Tracy\Panel::renderException

TypeError: Return value of Dibi\Bridges\Tracy\Panel::renderException() must be of the type array or null, none returned in ...\vendor\dibi\dibi\src\Dibi\Bridges\Tracy\Panel.php:78
```