### PR TITLE
Ensuring that an integer is returned, if postgres returned a string within Dibi\Drivers\PostgreDriver::getInsertId

### DIFF
--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -199,17 +199,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		}
 
 		$row = $res->fetch(false);
-
-		// The return value could be a string. If so, change it to an int.
-		if (is_array($row)) {
-			if (is_string($row[0])) {
-				return intval($row[0]);
-			}
-
-			return $row[0];
-		}
-
-		return null;
+		return is_array($row) ? (int) $row[0] : null;
 	}
 
 

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -199,6 +199,12 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		}
 
 		$row = $res->fetch(false);
+
+		// The return value could be a string. If so, change it to an int.
+		if (is_array($row) && is_string($row[0])) {
+			$row[0] = intval($row[0]);
+		}
+
 		return is_array($row) ? $row[0] : null;
 	}
 

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -201,11 +201,15 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		$row = $res->fetch(false);
 
 		// The return value could be a string. If so, change it to an int.
-		if (is_array($row) && is_string($row[0])) {
-			$row[0] = intval($row[0]);
+		if (is_array($row)) {
+			if (is_string($row[0])) {
+				return intval($row[0]);
+			}
+
+			return $row[0];
 		}
 
-		return is_array($row) ? $row[0] : null;
+		return null;
 	}
 
 


### PR DESCRIPTION
- bug fix? yes. Issue #270 
- new feature? no
- BC break? no

Postgres can return a string when selecting 'LASTVAL' or 'CURRVAL'. This code change ensures that an integer is always returned when calling 'Dibi\Drivers\PostgreDriver::getInsertId'