### PR TITLE
Make drivers more extensible

### DIFF
--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -150,7 +150,7 @@ class MySqliDriver implements Dibi\Driver, Dibi\ResultDriver
 		$res = @mysqli_query($this->connection, $sql, $this->buffered ? MYSQLI_STORE_RESULT : MYSQLI_USE_RESULT); // intentionally @
 
 		if ($code = mysqli_errno($this->connection)) {
-			throw self::createException(mysqli_error($this->connection), $code, $sql);
+			throw static::createException(mysqli_error($this->connection), $code, $sql);
 
 		} elseif (is_object($res)) {
 			return $this->createResultDriver($res);

--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -120,7 +120,7 @@ class OracleDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 			@oci_execute($res, $this->autocommit ? OCI_COMMIT_ON_SUCCESS : OCI_DEFAULT);
 			$err = oci_error($res);
 			if ($err) {
-				throw self::createException($err['message'], $err['code'], $sql);
+				throw static::createException($err['message'], $err['code'], $sql);
 
 			} elseif (is_resource($res)) {
 				$this->affectedRows = oci_num_rows($res);

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -96,7 +96,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_VERBOSE);
 
 		if (isset($config['charset']) && pg_set_client_encoding($this->connection, $config['charset'])) {
-			throw self::createException(pg_last_error($this->connection));
+			throw static::createException(pg_last_error($this->connection));
 		}
 
 		if (isset($config['schema'])) {
@@ -137,7 +137,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		$res = @pg_query($this->connection, $sql); // intentionally @
 
 		if ($res === false) {
-			throw self::createException(pg_last_error($this->connection), null, $sql);
+			throw static::createException(pg_last_error($this->connection), null, $sql);
 
 		} elseif (is_resource($res)) {
 			$this->affectedRows = pg_affected_rows($res);

--- a/src/Dibi/Drivers/Sqlite3Driver.php
+++ b/src/Dibi/Drivers/Sqlite3Driver.php
@@ -117,7 +117,7 @@ class Sqlite3Driver implements Dibi\Driver, Dibi\ResultDriver
 
 		$res = @$this->connection->query($sql); // intentionally @
 		if ($code = $this->connection->lastErrorCode()) {
-			throw self::createException($this->connection->lastErrorMsg(), $code, $sql);
+			throw static::createException($this->connection->lastErrorMsg(), $code, $sql);
 
 		} elseif ($res instanceof \SQLite3Result && $res->numColumns()) {
 			return $this->createResultDriver($res);


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

I would like to override public static method `createException()` and add more exception types for PostgreSQL.
