### PR TITLE
Previous exception can now be passed to Dibi\Exception constructor

### DIFF
--- a/src/Dibi/exceptions.php
+++ b/src/Dibi/exceptions.php
@@ -22,9 +22,9 @@ class Exception extends \Exception
 	/**
 	 * Construct a dibi exception.
 	 */
-	public function __construct(string $message = '', $code = 0, string $sql = null)
+	public function __construct(string $message = '', $code = 0, string $sql = null, \Throwable $previous = null)
 	{
-		parent::__construct($message);
+		parent::__construct($message, $code, $previous);
 		$this->code = $code;
 		$this->sql = $sql;
 	}

--- a/src/Dibi/exceptions.php
+++ b/src/Dibi/exceptions.php
@@ -24,7 +24,7 @@ class Exception extends \Exception
 	 */
 	public function __construct(string $message = '', $code = 0, string $sql = null, \Throwable $previous = null)
 	{
-		parent::__construct($message, $code, $previous);
+		parent::__construct($message, 0, $previous);
 		$this->code = $code;
 		$this->sql = $sql;
 	}


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

Fixes #254 (hope I didn't forget anything).

Note: I didn't add the `$previous` argument to `ProcedureException` constructor because it seemed to be an internal exception and its usage didn't suggest it could benefit from such argument.