### PR TITLE
fix Firebird datetime precision

### DIFF
--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -284,7 +284,7 @@ class FirebirdDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		if (!$value instanceof \DateTimeInterface) {
 			$value = new Dibi\DateTime($value);
 		}
-		return $value->format("'Y-m-d H:i:s.u'");
+		return "'" . substr($value->format("Y-m-d H:i:s.u"), 0, -2) . "'";
 	}
 
 

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -284,7 +284,7 @@ class FirebirdDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 		if (!$value instanceof \DateTimeInterface) {
 			$value = new Dibi\DateTime($value);
 		}
-		return "'" . substr($value->format("Y-m-d H:i:s.u"), 0, -2) . "'";
+		return "'" . substr($value->format('Y-m-d H:i:s.u'), 0, -2) . "'";
 	}
 
 


### PR DESCRIPTION
- bug fix? yes - fixes #273
- new feature? no
- BC break? no

The Firebird driver formats full date & time with microsecond precision, but this results in a conversion error when run against a Firebird 3.0.1 server. TIMESTAMP in Firebird Dialect 3 (which itself is equivalent to DATE in Dialect 1) only supports decimillisecond resolution (10e-4).