### PR TITLE
driver's connect() & disconnect() replaced with constructor & desctructor

### DIFF
--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -34,9 +34,6 @@ class Connection implements IConnection
 	/** @var Translator|null */
 	private $translator;
 
-	/** @var bool  Is connected? */
-	private $connected = false;
-
 	/** @var HashMap Substitutes for identifiers */
 	private $substitutes;
 
@@ -128,7 +125,6 @@ class Connection implements IConnection
 		$event = $this->onEvent ? new Event($this, Event::CONNECT) : null;
 		try {
 			$this->driver = new $class($this->config);
-			$this->connected = true;
 			if ($event) {
 				$this->onEvent($event->done());
 			}
@@ -147,9 +143,9 @@ class Connection implements IConnection
 	 */
 	final public function disconnect(): void
 	{
-		if ($this->connected) {
+		if ($this->driver) {
 			$this->driver->disconnect();
-			$this->connected = false;
+			$this->driver = false;
 		}
 	}
 
@@ -159,7 +155,7 @@ class Connection implements IConnection
 	 */
 	final public function isConnected(): bool
 	{
-		return $this->connected;
+		return (bool) $this->driver;
 	}
 
 
@@ -181,7 +177,7 @@ class Connection implements IConnection
 	 */
 	final public function getDriver(): Driver
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		return $this->driver;
@@ -248,7 +244,7 @@ class Connection implements IConnection
 	 */
 	protected function translateArgs(array $args): string
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		if (!$this->translator) {
@@ -266,7 +262,7 @@ class Connection implements IConnection
 	 */
 	final public function nativeQuery(string $sql)
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 
@@ -301,7 +297,7 @@ class Connection implements IConnection
 	 */
 	public function getAffectedRows(): int
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		$rows = $this->driver->getAffectedRows();
@@ -328,7 +324,7 @@ class Connection implements IConnection
 	 */
 	public function getInsertId(string $sequence = null): int
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		$id = $this->driver->getInsertId($sequence);
@@ -354,7 +350,7 @@ class Connection implements IConnection
 	 */
 	public function begin(string $savepoint = null): void
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		$event = $this->onEvent ? new Event($this, Event::BEGIN, $savepoint) : null;
@@ -378,7 +374,7 @@ class Connection implements IConnection
 	 */
 	public function commit(string $savepoint = null): void
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		$event = $this->onEvent ? new Event($this, Event::COMMIT, $savepoint) : null;
@@ -402,7 +398,7 @@ class Connection implements IConnection
 	 */
 	public function rollback(string $savepoint = null): void
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		$event = $this->onEvent ? new Event($this, Event::ROLLBACK, $savepoint) : null;
@@ -572,7 +568,7 @@ class Connection implements IConnection
 	 */
 	public function getDatabaseInfo(): Reflection\Database
 	{
-		if (!$this->connected) {
+		if (!$this->driver) {
 			$this->connect();
 		}
 		return new Reflection\Database($this->driver->getReflector(), $this->config['database'] ?? null);

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -30,7 +30,7 @@ class FirebirdDriver implements Dibi\Driver, Dibi\Reflector
 
 	public const ERROR_EXCEPTION_THROWN = -836;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 	/** @var resource|null */
@@ -43,20 +43,12 @@ class FirebirdDriver implements Dibi\Driver, Dibi\Reflector
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('interbase')) {
 			throw new Dibi\NotSupportedException("PHP extension 'interbase' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		Helpers::alias($config, 'database', 'db');
 
 		if (isset($config['resource'])) {

--- a/src/Dibi/Drivers/MsSqlDriver.php
+++ b/src/Dibi/Drivers/MsSqlDriver.php
@@ -27,27 +27,19 @@ class MsSqlDriver implements Dibi\Driver
 {
 	use Dibi\Strict;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('mssql')) {
 			throw new Dibi\NotSupportedException("PHP extension 'mssql' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		if (isset($config['resource'])) {
 			$this->connection = $config['resource'];
 		} elseif (empty($config['persistent'])) {

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -40,7 +40,7 @@ class MySqliDriver implements Dibi\Driver
 
 	public const ERROR_DATA_TRUNCATED = 1265;
 
-	/** @var \mysqli|null */
+	/** @var \mysqli */
 	private $connection;
 
 	/** @var bool  Is buffered (seekable and countable)? */
@@ -50,20 +50,12 @@ class MySqliDriver implements Dibi\Driver
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('mysqli')) {
 			throw new Dibi\NotSupportedException("PHP extension 'mysqli' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		mysqli_report(MYSQLI_REPORT_OFF);
 		if (isset($config['resource'])) {
 			$this->connection = $config['resource'];

--- a/src/Dibi/Drivers/OdbcDriver.php
+++ b/src/Dibi/Drivers/OdbcDriver.php
@@ -26,7 +26,7 @@ class OdbcDriver implements Dibi\Driver, Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 	/** @var int|null  Affected rows */
@@ -36,20 +36,12 @@ class OdbcDriver implements Dibi\Driver, Dibi\Reflector
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('odbc')) {
 			throw new Dibi\NotSupportedException("PHP extension 'odbc' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		if (isset($config['resource'])) {
 			$this->connection = $config['resource'];
 		} else {

--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -29,7 +29,7 @@ class OracleDriver implements Dibi\Driver, Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 	/** @var bool */
@@ -45,20 +45,12 @@ class OracleDriver implements Dibi\Driver, Dibi\Reflector
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('oci8')) {
 			throw new Dibi\NotSupportedException("PHP extension 'oci8' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		$foo = &$config['charset'];
 
 		if (isset($config['formatDate']) || isset($config['formatDateTime'])) {

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -45,20 +45,12 @@ class PdoDriver implements Dibi\Driver
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('pdo')) {
 			throw new Dibi\NotSupportedException("PHP extension 'pdo' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		$foo = &$config['dsn'];
 		$foo = &$config['options'];
 		Helpers::alias($config, 'resource', 'pdo');

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -28,7 +28,7 @@ class PostgreDriver implements Dibi\Driver, Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 	/** @var int|null  Affected rows */
@@ -38,20 +38,12 @@ class PostgreDriver implements Dibi\Driver, Dibi\Reflector
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('pgsql')) {
 			throw new Dibi\NotSupportedException("PHP extension 'pgsql' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		$error = null;
 		if (isset($config['resource'])) {
 			$this->connection = $config['resource'];

--- a/src/Dibi/Drivers/Sqlite3Driver.php
+++ b/src/Dibi/Drivers/Sqlite3Driver.php
@@ -27,7 +27,7 @@ class Sqlite3Driver implements Dibi\Driver
 {
 	use Dibi\Strict;
 
-	/** @var SQLite3|null */
+	/** @var SQLite3 */
 	private $connection;
 
 	/** @var string  Date format */
@@ -40,20 +40,12 @@ class Sqlite3Driver implements Dibi\Driver
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('sqlite3')) {
 			throw new Dibi\NotSupportedException("PHP extension 'sqlite3' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		if (isset($config['dbcharset']) || isset($config['charset'])) {
 			throw new Dibi\NotSupportedException('Options dbcharset and charset are not longer supported.');
 		}

--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -29,7 +29,7 @@ class SqlsrvDriver implements Dibi\Driver
 {
 	use Dibi\Strict;
 
-	/** @var resource|null */
+	/** @var resource */
 	private $connection;
 
 	/** @var int|null  Affected rows */
@@ -42,20 +42,12 @@ class SqlsrvDriver implements Dibi\Driver
 	/**
 	 * @throws Dibi\NotSupportedException
 	 */
-	public function __construct()
+	public function __construct(array &$config)
 	{
 		if (!extension_loaded('sqlsrv')) {
 			throw new Dibi\NotSupportedException("PHP extension 'sqlsrv' is not loaded.");
 		}
-	}
 
-
-	/**
-	 * Connects to a database.
-	 * @throws Dibi\Exception
-	 */
-	public function connect(array &$config): void
-	{
 		Helpers::alias($config, 'options|UID', 'username');
 		Helpers::alias($config, 'options|PWD', 'password');
 		Helpers::alias($config, 'options|Database', 'database');

--- a/src/Dibi/interfaces.php
+++ b/src/Dibi/interfaces.php
@@ -26,12 +26,6 @@ interface IDataSource extends \Countable, \IteratorAggregate
 interface Driver
 {
 	/**
-	 * Connects to a database.
-	 * @throws Exception
-	 */
-	function connect(array &$config): void;
-
-	/**
 	 * Disconnects from a database.
 	 * @throws Exception
 	 */


### PR DESCRIPTION
- new feature? yes
- BC break? yes

Instance of driver exists as long as exist DB connection (instead of object Dibi\Connection). So driver's property `$resource` is always `resource` or `mysqli` object, and not `resource|null` or `mysqli|null`.

cc @milo 