### PR TITLE
PdoDriver: check for misconfigured PDO connections resource (target 3.3.x and 4.0.x)

### DIFF
--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -72,8 +72,8 @@ class PdoDriver implements Dibi\Driver
 		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 		$this->serverVersion = (string) ($config['version'] ?? @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)); // @ - may be not supported
 
-		if (!\in_array($this->connection->getAttribute(\PDO::ATTR_ERRMODE), [null, \PDO::ERRMODE_WARNING], true)) {
-			throw new Dibi\DriverException('PDO connection in other error mode then WARNING (default) is currently not supported. Consider upgrading to Dibi >=4.1.0.');
+		if ($this->connection->getAttribute(\PDO::ATTR_ERRMODE) !== \PDO::ERRMODE_SILENT)  {
+			throw new Dibi\DriverException('PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 		}
 	}
 

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -69,12 +69,13 @@ class PdoDriver implements Dibi\Driver
 			}
 		}
 
-		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
-		$this->serverVersion = (string) ($config['version'] ?? @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)); // @ - may be not supported
-
 		if ($this->connection->getAttribute(\PDO::ATTR_ERRMODE) !== \PDO::ERRMODE_SILENT) {
 			throw new Dibi\DriverException('PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 		}
+
+		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+		$this->serverVersion = (string) ($config['version'] ?? @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)); // @ - may be not supported
+
 	}
 
 

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -71,6 +71,10 @@ class PdoDriver implements Dibi\Driver
 
 		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 		$this->serverVersion = (string) ($config['version'] ?? @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)); // @ - may be not supported
+
+		if (!\in_array($this->connection->getAttribute(\PDO::ATTR_ERRMODE), [null, \PDO::ERRMODE_WARNING], true)) {
+			throw new Dibi\DriverException('PDO connection in other error mode then WARNING (default) is currently not supported. Consider upgrading to Dibi >=4.1.0.');
+		}
 	}
 
 

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -72,7 +72,7 @@ class PdoDriver implements Dibi\Driver
 		$this->driverName = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 		$this->serverVersion = (string) ($config['version'] ?? @$this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)); // @ - may be not supported
 
-		if ($this->connection->getAttribute(\PDO::ATTR_ERRMODE) !== \PDO::ERRMODE_SILENT)  {
+		if ($this->connection->getAttribute(\PDO::ATTR_ERRMODE) !== \PDO::ERRMODE_SILENT) {
 			throw new Dibi\DriverException('PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 		}
 	}

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -29,7 +29,7 @@ Assert::exception(function() use ($config) {
 
 // PDO error mode: warning
 Assert::exception(function() use ($config) {
-	($pdoConnection = new PDO($config['dsn']))->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+	($pdoConnection = new PDO($config['dsn']))->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_WARNING);
 	buildPdoDriver($pdoConnection);
 }, \Dibi\DriverException::class, 'PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -4,6 +4,12 @@
  * @dataProvider ../databases.ini != nothing, pdo
  */
 
+// Background:
+// When PDO connection is passed into Dibi it can be in (re)configured in various ways.
+// This affects how connection is then internally handled.
+// There should be no visible difference in Dibi behaviour regardless of PDO configuration (except unsupported configurations).
+
+
 declare(strict_types=1);
 
 use Tester\Assert;

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @dataProvider ../databases.ini
+ * @dataProvider ../databases.ini != no match, pdo
  */
 
 declare(strict_types=1);
@@ -9,10 +9,6 @@ declare(strict_types=1);
 use Tester\Assert;
 
 require __DIR__ . '/bootstrap.php';
-
-if($config['driver'] !== 'pdo') {
-	\Tester\Environment::skip('Only relevant for PDO driver.');
-}
 
 /** @throws \Dibi\NotSupportedException */
 function buildPdoDriver(PDO $pdo): \Dibi\Drivers\PdoDriver {

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @dataProvider ../databases.ini
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+if($config['driver'] !== 'pdo') {
+	\Tester\Environment::skip('Only relevant for PDO driver.');
+}
+
+/** @throws \Dibi\NotSupportedException */
+function buildPdoDriver(PDO $pdo): \Dibi\Drivers\PdoDriver {
+	$driverConfig = ['resource' => $pdo];
+	return new \Dibi\Drivers\PdoDriver($driverConfig);
+}
+
+// PDO error mode: exception
+Assert::exception(function() use ($config) {
+	($pdoConnection = new PDO($config['dsn']))->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+	buildPdoDriver($pdoConnection);
+}, \Dibi\DriverException::class, 'PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
+
+
+// PDO error mode: warning
+Assert::exception(function() use ($config) {
+	($pdoConnection = new PDO($config['dsn']))->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+	buildPdoDriver($pdoConnection);
+}, \Dibi\DriverException::class, 'PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
+
+
+// PDO error mode: explicitly set silent
+test(function() use ($config) {
+	($pdoConnection = new PDO($config['dsn']))->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
+	Assert::type(\Dibi\Drivers\PdoDriver::class, buildPdoDriver($pdoConnection));
+});
+
+
+// PDO error mode: implicitly set silent
+test(function() use ($config) {
+	$pdoConnection = new PDO($config['dsn']);
+	Assert::type(\Dibi\Drivers\PdoDriver::class, buildPdoDriver($pdoConnection));
+});

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @dataProvider ../databases.ini != no match, pdo
+ * @dataProvider ../databases.ini != nothing, pdo
  */
 
 declare(strict_types=1);

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -17,7 +17,8 @@ use Tester\Assert;
 require __DIR__ . '/bootstrap.php';
 
 
-function buildPDOConnection(int $errorMode = NULL): PDO {
+function buildPDOConnection(int $errorMode = null): PDO
+{
 	global $config;
 
 	// used to parse config, establish connection
@@ -28,7 +29,7 @@ function buildPDOConnection(int $errorMode = NULL): PDO {
 	// hack: extract PDO connection from driver (no public interface for that)
 	$connectionProperty = (new ReflectionClass($dibiDriver))
 		->getProperty('connection');
-	$connectionProperty->setAccessible(TRUE);
+	$connectionProperty->setAccessible(true);
 	$pdo = $connectionProperty->getValue($dibiDriver);
 	\assert($pdo instanceof PDO);
 
@@ -36,42 +37,44 @@ function buildPDOConnection(int $errorMode = NULL): PDO {
 	\assert($pdo->getAttribute(\PDO::ATTR_ERRMODE) === \PDO::ERRMODE_SILENT);
 
 	// override PDO error mode if provided
-	if ($errorMode !== NULL) {
+	if ($errorMode !== null) {
 		$pdo->setAttribute(\PDO::ATTR_ERRMODE, $errorMode);
 	}
 	return $pdo;
 }
 
+
 /** @throws \Dibi\NotSupportedException */
-function buildPdoDriverWithProvidedConnection(PDO $pdo): \Dibi\Drivers\PdoDriver {
+function buildPdoDriverWithProvidedConnection(PDO $pdo): \Dibi\Drivers\PdoDriver
+{
 	$driverConfig = ['resource' => $pdo];
 	return new \Dibi\Drivers\PdoDriver($driverConfig);
 }
 
 
 // PDO error mode: exception
-Assert::exception(function() {
+Assert::exception(function () {
 	$pdoConnection = buildPDOConnection(\PDO::ERRMODE_EXCEPTION);
 	buildPdoDriverWithProvidedConnection($pdoConnection);
 }, \Dibi\DriverException::class, 'PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 
 
 // PDO error mode: warning
-Assert::exception(function() {
+Assert::exception(function () {
 	$pdoConnection = buildPDOConnection(\PDO::ERRMODE_WARNING);
 	buildPdoDriverWithProvidedConnection($pdoConnection);
 }, \Dibi\DriverException::class, 'PDO connection in exception or warning error mode is currently not supported. Consider upgrading to Dibi >=4.1.0.');
 
 
 // PDO error mode: explicitly set silent
-test(function() {
+test(function () {
 	$pdoConnection = buildPDOConnection(\PDO::ERRMODE_SILENT);
 	Assert::type(\Dibi\Drivers\PdoDriver::class, buildPdoDriverWithProvidedConnection($pdoConnection));
 });
 
 
 // PDO error mode: implicitly set silent
-test(function() {
-	$pdoConnection = buildPDOConnection(NULL);
+test(function () {
+	$pdoConnection = buildPDOConnection(null);
 	Assert::type(\Dibi\Drivers\PdoDriver::class, buildPdoDriverWithProvidedConnection($pdoConnection));
 });


### PR DESCRIPTION
- bug fix
- BC break? no (as original behaviour should be considered as broken)

see #292 