### PR TITLE
this extra type will break a static analysis for usage without alias

### DIFF
--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -15,7 +15,7 @@ namespace Dibi;
  *
  * @method Fluent select(...$field)
  * @method Fluent distinct()
- * @method Fluent from($table, ...$args)
+ * @method Fluent from($table, ...$args = null)
  * @method Fluent where(...$cond)
  * @method Fluent groupBy(...$field)
  * @method Fluent having(...$cond)


### PR DESCRIPTION
has been introduced by this commit:
https://github.com/dg/dibi/commit/0d5fd9d65b6421d871834dbc5026835b06da7313

for example fluent:

```
$dibiConnection->select(‘id’)
    ->from(‘users’);
```

will not pass static analysis although is completely valid code.

- bug fix
- BC break? no

Anyway thanks for a great tool for simple stuff with SQL - saved a lot of work already 🙏 .