### PR TITLE
Add annotations for methods and(), asc(), desc() in \Dibi\Fluent #298

### DIFF
--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -29,7 +29,10 @@ namespace Dibi;
  * @method Fluent outerJoin(...$table)
  * @method Fluent as(...$field)
  * @method Fluent on(...$cond)
+ * @method Fluent and(...$cond)
  * @method Fluent using(...$cond)
+ * @method Fluent asc()
+ * @method Fluent desc()
  */
 class Fluent implements IDataSource
 {


### PR DESCRIPTION
- new feature, #298 
- BC break? no

Allows static analyst tools to understand code like :
```$fluent->where('columnA = 1')->and('columnB = 2');```
