### PR TITLE
Connection config onConnect

### DIFF
--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -47,6 +47,7 @@ class Connection implements IConnection
 	 *       - run (bool) => enable profiler?
 	 *       - file => file to log
 	 *   - substitutes (array) => map of driver specific substitutes (under development)
+	 *   - onConnect (array) => list of SQL queries to execute (by Connection::query()) after connection is established
 	 * @param  array   $config  connection parameters
 	 * @throws Exception
 	 */
@@ -90,6 +91,10 @@ class Connection implements IConnection
 			}
 		}
 
+		if (isset($config['onConnect']) && !is_array($config['onConnect'])) {
+			throw new \InvalidArgumentException("Configuration option 'onConnect' must be array.");
+		}
+
 		if (empty($config['lazy'])) {
 			$this->connect();
 		}
@@ -127,6 +132,11 @@ class Connection implements IConnection
 			$this->driver = new $class($this->config);
 			if ($event) {
 				$this->onEvent($event->done());
+			}
+			if (isset($this->config['onConnect'])) {
+				foreach ($this->config['onConnect'] as $sql) {
+					$this->query($sql);
+				}
 			}
 
 		} catch (DriverException $e) {

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -276,7 +276,8 @@ class FirebirdDriver implements Dibi\Driver
 	 */
 	public function escapeLike(string $value, int $pos): string
 	{
-		throw new Dibi\NotImplementedException;
+		$value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\n\r\\'%_");
+		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
 	}
 
 

--- a/tests/dibi/Connection.connect.phpt
+++ b/tests/dibi/Connection.connect.phpt
@@ -50,3 +50,27 @@ test(function () use ($config) {
 	$conn->disconnect();
 	Assert::false($conn->isConnected());
 });
+
+
+test(function () use ($config) {
+	Assert::exception(function () use ($config) {
+		new Connection($config + ['onConnect' => '']);
+	}, InvalidArgumentException::class, "Configuration option 'onConnect' must be array.");
+
+	$e = Assert::exception(function () use ($config) {
+		new Connection($config + ['onConnect' => ['STOP']]);
+	}, Dibi\DriverException::class);
+	Assert::same('STOP', $e->getSql());
+
+	$e = Assert::exception(function () use ($config) {
+		new Connection($config + ['onConnect' => [['STOP %i', 123]]]);
+	}, Dibi\DriverException::class);
+	Assert::same('STOP 123', $e->getSql());
+
+	// lazy
+	$conn = new Connection($config + ['lazy' => true, 'onConnect' => ['STOP']]);
+	$e = Assert::exception(function () use ($conn) {
+		$conn->query('SELECT 1');
+	}, Dibi\DriverException::class);
+	Assert::same('STOP', $e->getSql());
+});


### PR DESCRIPTION
- new feature
- BC break? no

onConnect option is an array of SQL queries run by `Connection::query()` right after a database connection is established.

It is "hard" to run SQL queries once when a connection is established, especially in non-lazy configuration. Such queries are usually part of the connection setup phase, like:
- `['ALTER SESSION SET NLS_DATE_FORMAT = %s', 'YYYY-MM-DD']` (by Oracle)
- `PRAGMA foreign_keys=true` by #301 (by SQLite)
- `SET application_name = 'MyApp';` (by PostgreSQL)

In lazy mode, the `Dibi\Event` can be used, but such event is invoked by every next SQL query which is not necessary. Moreover, when used with Nette DI, it requires some stuff/boilerplate code to achive that. This solution seems clear to me, setup queries are kept near configuration.

For onConnect option, I was thinking about callbacks instead of SQL queries. It would be more universal, but harder to write by configuration, NEON for example. IMHO, callbacks can by added later without BC break.