### PR TITLE
fix TypeError: substr() expects parameter 1 to be string, null given

### DIFF
--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -130,7 +130,7 @@ class PostgreReflector implements Dibi\Reflector
 				'size' => $size > 0 ? $size : null,
 				'nullable' => $row['is_nullable'] === 'YES' || $row['is_nullable'] === 't' || $row['is_nullable'] === true,
 				'default' => $row['column_default'],
-				'autoincrement' => (int) $row['ordinal_position'] === $primary && substr($row['column_default'], 0, 7) === 'nextval',
+				'autoincrement' => (int) $row['ordinal_position'] === $primary && substr($row['column_default'] ?? '', 0, 7) === 'nextval',
 				'vendor' => $row,
 			];
 		}


### PR DESCRIPTION
- bug fix
- BC break? no

fix for TypeError: substr() expects parameter 1 to be string, null given