### PR TITLE
fix Type Error

### DIFF
--- a/src/Dibi/Reflection/Column.php
+++ b/src/Dibi/Reflection/Column.php
@@ -76,7 +76,7 @@ class Column
 	}
 
 
-	public function getType(): string
+	public function getType(): ?string
 	{
 		return Dibi\Helpers::getTypeCache()->{$this->info['nativetype']};
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

fix for:

TypeError: Return value of Dibi\Reflection\Column::getType() must be of the type string, null returned