### PR TITLE
Result::normalize() Fix select float in format of e-notation (#317)  v3.2

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -498,8 +498,11 @@ class Result implements IDataSource
 			} elseif ($type === Type::FLOAT) {
 				$value = ltrim((string) $value, '0');
 				$p = strpos($value, '.');
-				if ($p !== false) {
+				$e = strpos($value, 'e');
+				if ($p !== false && $e === flase) {
 					$value = rtrim(rtrim($value, '0'), '.');
+				} elseif ($p !== false && $e !== false) {
+					$value = rtrim($value, '.');
 				}
 				if ($value === '' || $value[0] === '.') {
 					$value = '0' . $value;


### PR DESCRIPTION
- bug fix  #317 for version 3.2
- BC break? no
- changes as suggested in #317 