### PR TITLE
Result::normalize() Fix select float in format of e-notation (#317) v3.2

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -498,8 +498,11 @@ class Result implements IDataSource
 			} elseif ($type === Type::FLOAT) {
 				$value = ltrim((string) $value, '0');
 				$p = strpos($value, '.');
-				if ($p !== false) {
+				$e = strpos($value, 'e');
+				if ($p !== false && $e === false) {
 					$value = rtrim(rtrim($value, '0'), '.');
+				} elseif ($p !== false && $e !== false) {
+					$value = rtrim($value, '.');
 				}
 				if ($value === '' || $value[0] === '.') {
 					$value = '0' . $value;

--- a/tests/dibi/Result.normalize.phpt
+++ b/tests/dibi/Result.normalize.phpt
@@ -99,6 +99,11 @@ test(function () {
 	Assert::same(['col' => 1.0], $result->test(['col' => 1]));
 	Assert::same(['col' => 1.0], $result->test(['col' => 1.0]));
 
+	Assert::same(['col' => '1.1e+10'], $result->test(['col' => '1.1e+10']));
+	Assert::same(['col' => '1.1e-10'], $result->test(['col' => '1.1e-10']));
+	Assert::same(['col' => '1.1e+10'], $result->test(['col' => '001.1e+10']));
+	Assert::notSame(['col' => '1.1e+1'], $result->test(['col' => '1.1e+10']));
+
 	setlocale(LC_ALL, 'de_DE@euro', 'de_DE', 'deu_deu');
 	Assert::same(['col' => 0.0], $result->test(['col' => '']));
 	Assert::same(['col' => 0.0], $result->test(['col' => '0']));


### PR DESCRIPTION
* bug fix #317 for version v3.2
* BC break? no
* changes as suggested in #317
