### PR TITLE
Add Result::getTypes to get all columns and its types

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -523,6 +523,15 @@ class Result implements IDataSource
 
 
 	/**
+	 * Returns columns type.
+	 */
+	final public function getTypes(): array
+	{
+		return $this->types;
+	}
+
+
+	/**
 	 * Sets date format.
 	 */
 	final public function setFormat(string $type, ?string $format): self


### PR DESCRIPTION
- bug fix / new feature?
new feature

- BC break? yes/no
no

Added getTypes method, to get all columns and its types, this is faster then write foreach for getting all columns, and getColumns do not get column type (there is null).