### PR TITLE
Dibi\Fluent: add annotation for methods or()

### DIFF
--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -30,6 +30,7 @@ namespace Dibi;
  * @method Fluent as(...$field)
  * @method Fluent on(...$cond)
  * @method Fluent and(...$cond)
+ * @method Fluent or(...$cond)
  * @method Fluent using(...$cond)
  * @method Fluent asc()
  * @method Fluent desc()


### PR DESCRIPTION
- new feature
- BC break? no

Allows static analyst tools to understand code like :
`$fluent->where('columnA = 1')->or('columnB = 2');`
