### PR TITLE
Failing test for DateInterval usage

### DIFF
--- a/tests/dibi/Translator.DateInterval.phpt
+++ b/tests/dibi/Translator.DateInterval.phpt
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+$conn = new Dibi\Connection($config);
+$translator = new Dibi\Translator($conn);
+
+$dateinterval = new DateInterval('PT10H20M30S');
+
+Assert::equal('10:20:30', $translator->formatValue($dateinterval, null));


### PR DESCRIPTION
Dibi returns `TIME` values as `DateInterval` (for MySQL) but using of `DateInterval` in queries fails with `**Unexpected DateInterval**`.

See https://forum.nette.org/cs/32482-dibi-sloupec-time-a-jeho-zapis#p205778

I don't know how to fix it - maybe add new `Driver::escapeTime()` method?