### PR TITLE
Connection: added option [result][formatJson] that sets json column decoding (string|object|array)

### DIFF
--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -43,6 +43,11 @@ class Connection implements IConnection
 	 *   - lazy (bool) => if true, connection will be established only when required
 	 *   - result (array) => result set options
 	 *       - formatDateTime => date-time format (if empty, DateTime objects will be returned)
+	 *       - formatJson => json format (
+	 *           "string" for leaving value as is,
+	 *           "object" for decoding json as \stdClass,
+	 *           "array" for decoding json as an array - default
+	 *       )
 	 *   - profiler (array)
 	 *       - run (bool) => enable profiler?
 	 *       - file => file to log
@@ -59,6 +64,7 @@ class Connection implements IConnection
 		Helpers::alias($config, 'result|formatDateTime', 'resultDateTime');
 		$config['driver'] = $config['driver'] ?? 'mysqli';
 		$config['name'] = $name;
+		$config['result']['formatJson'] = $config['result']['formatJson'] ?? 'array';
 		$this->config = $config;
 
 		// profiler
@@ -395,7 +401,8 @@ class Connection implements IConnection
 	{
 		$res = new Result($resultDriver);
 		return $res->setFormat(Type::DATE, $this->config['result']['formatDate'])
-			->setFormat(Type::DATETIME, $this->config['result']['formatDateTime']);
+			->setFormat(Type::DATETIME, $this->config['result']['formatDateTime'])
+			->setFormat(Type::JSON, $this->config['result']['formatJson']);
 	}
 
 

--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -496,7 +496,11 @@ class Result implements IDataSource
 				$row[$key] = is_string($value) ? $this->getResultDriver()->unescapeBinary($value) : $value;
 
 			} elseif ($type === Type::JSON) {
-				$row[$key] = json_decode($value, true);
+				if ($this->formats[$type] === 'string') {
+					$row[$key] = $value;
+				} else {
+					$row[$key] = json_decode($value, $this->formats[$type] === 'array');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- new feature? yes
- BC break? no

`Dibi\Connection($config)` -> added new option `$config['result']['formatJson']` to tell the `Dibi\Result` how to format `json` column. 3 options available: `array` (default, therefore no BC breaks), `object` (formatting json to \stdClass) and `string`.
