### PR TITLE
SqlsrvResult: fixed illegal false return value from sqlsrv_fetch_array()

### DIFF
--- a/src/Dibi/Drivers/SqlsrvResult.php
+++ b/src/Dibi/Drivers/SqlsrvResult.php
@@ -61,7 +61,7 @@ class SqlsrvResult implements Dibi\ResultDriver
 	 */
 	public function fetch(bool $assoc): ?array
 	{
-		return sqlsrv_fetch_array($this->resultSet, $assoc ? SQLSRV_FETCH_ASSOC : SQLSRV_FETCH_NUMERIC);
+		return Dibi\Helpers::false2Null(sqlsrv_fetch_array($this->resultSet, $assoc ? SQLSRV_FETCH_ASSOC : SQLSRV_FETCH_NUMERIC));
 	}
 
 


### PR DESCRIPTION
On error, sqlsrv_fetch_array() returns false, which causes an error due to the return type declaration. This commit handles that by casting such value to null the same way other result drivers do it.