### PR TITLE
Add support for escapeLike without % on any side

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ Three special modifiers are available for LIKE:
 | `%like~` | the expression starts with a string
 | `%~like` | the expression ends with a string
 | `%~like~` | the expression contains a string
+| `%like` | the expression matches a string
 
 Search for names beginning with a string:
 

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -268,10 +268,10 @@ class FirebirdDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = addcslashes($this->escapeText($value), '%_\\');
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'") . " ESCAPE '\\'";
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'") . " ESCAPE '\\'";
 	}
 
 

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -314,10 +314,10 @@ class MySqliDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\n\r\\'%_");
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 	}
 
 

--- a/src/Dibi/Drivers/OdbcDriver.php
+++ b/src/Dibi/Drivers/OdbcDriver.php
@@ -247,10 +247,10 @@ class OdbcDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = strtr($value, ["'" => "''", '%' => '[%]', '_' => '[_]', '[' => '[[]']);
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 	}
 
 

--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -266,11 +266,11 @@ class OracleDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\\%_");
 		$value = str_replace("'", "''", $value);
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 	}
 
 

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -319,34 +319,34 @@ class PdoDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		switch ($this->driverName) {
 			case 'mysql':
 				$value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\n\r\\'%_");
-				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+				return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 
 			case 'oci':
 				$value = addcslashes(str_replace('\\', '\\\\', $value), "\x00\\%_");
 				$value = str_replace("'", "''", $value);
-				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+				return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 
 			case 'pgsql':
 				$bs = substr($this->connection->quote('\\', PDO::PARAM_STR), 1, -1); // standard_conforming_strings = on/off
 				$value = substr($this->connection->quote($value, PDO::PARAM_STR), 1, -1);
 				$value = strtr($value, ['%' => $bs . '%', '_' => $bs . '_', '\\' => '\\\\']);
-				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+				return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 
 			case 'sqlite':
 				$value = addcslashes(substr($this->connection->quote($value, PDO::PARAM_STR), 1, -1), '%_\\');
-				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'") . " ESCAPE '\\'";
+				return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'") . " ESCAPE '\\'";
 
 			case 'odbc':
 			case 'mssql':
 			case 'dblib':
 			case 'sqlsrv':
 				$value = strtr($value, ["'" => "''", '%' => '[%]', '_' => '[_]', '[' => '[[]']);
-				return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+				return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 
 			default:
 				throw new Dibi\NotImplementedException;

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -313,12 +313,12 @@ class PostgreDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$bs = pg_escape_string($this->connection, '\\'); // standard_conforming_strings = on/off
 		$value = pg_escape_string($this->connection, $value);
 		$value = strtr($value, ['%' => $bs . '%', '_' => $bs . '_', '\\' => '\\\\']);
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 	}
 
 

--- a/src/Dibi/Drivers/SqliteDriver.php
+++ b/src/Dibi/Drivers/SqliteDriver.php
@@ -251,10 +251,10 @@ class SqliteDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = addcslashes($this->connection->escapeString($value), '%_\\');
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'") . " ESCAPE '\\'";
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'") . " ESCAPE '\\'";
 	}
 
 

--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -240,10 +240,10 @@ class SqlsrvDriver implements Dibi\Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	public function escapeLike(string $value, int $pos): string
+	public function escapeLike(string $value, ?int $pos): string
 	{
 		$value = strtr($value, ["'" => "''", '%' => '[%]', '_' => '[_]', '[' => '[[]']);
-		return ($pos <= 0 ? "'%" : "'") . $value . ($pos >= 0 ? "%'" : "'");
+		return ($pos <= 0 && $pos !== null ? "'%" : "'") . $value . ($pos >= 0 && $pos !== null ? "%'" : "'");
 	}
 
 

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -423,6 +423,9 @@ final class Translator
 				case '~like~': // LIKE %string%
 					return $this->driver->escapeLike($value, 0);
 
+				case 'like': // LIKE string
+					return $this->driver->escapeLike($value, null);
+
 				case 'and':
 				case 'or':
 				case 'a':

--- a/src/Dibi/interfaces.php
+++ b/src/Dibi/interfaces.php
@@ -96,7 +96,7 @@ interface Driver
 	/**
 	 * Encodes string for use in a LIKE statement.
 	 */
-	function escapeLike(string $value, int $pos): string;
+	function escapeLike(string $value, ?int $pos): string;
 
 	/**
 	 * Injects LIMIT/OFFSET to the SQL query.

--- a/tests/dibi/Translator.like.phpt
+++ b/tests/dibi/Translator.like.phpt
@@ -71,3 +71,9 @@ Assert::truthy($conn->fetchSingle('SELECT ? LIKE %~like~', 'baa', 'aa'));
 Assert::truthy($conn->fetchSingle('SELECT ? LIKE %~like~', 'aab', 'aa'));
 Assert::falsey($conn->fetchSingle('SELECT ? LIKE %~like~', 'bba', '%a'));
 Assert::truthy($conn->fetchSingle('SELECT ? LIKE %~like~', 'b%a', '%a'));
+
+
+// matches
+Assert::truthy($conn->fetchSingle('SELECT ? LIKE %like', 'a', 'a'));
+Assert::falsey($conn->fetchSingle('SELECT ? LIKE %like', 'a', 'aa'));
+Assert::falsey($conn->fetchSingle('SELECT ? LIKE %like', 'a', 'b'));


### PR DESCRIPTION
It is required if you need to ignore letter case or diacritics on certain collations while maintaining characters properly escaped in LIKE query.

Tests added, not tested though.