### PR TITLE
PostgreDriver: fixed persistent connections

### DIFF
--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -69,7 +69,7 @@ class PostgreDriver implements Dibi\Driver
 			if (empty($config['persistent'])) {
 				$this->connection = pg_connect($string, PGSQL_CONNECT_FORCE_NEW);
 			} else {
-				$this->connection = pg_pconnect($string, PGSQL_CONNECT_FORCE_NEW);
+				$this->connection = pg_pconnect($string);
 			}
 			restore_error_handler();
 		}


### PR DESCRIPTION
- bug fix: config parameter 'persistent' has no effect on the connection
