### PR TITLE
MySqliDriver: coalesced password to an empty string

### DIFF
--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -91,7 +91,7 @@ class MySqliDriver implements Dibi\Driver
 			@$this->connection->real_connect( // intentionally @
 				(empty($config['persistent']) ? '' : 'p:') . $config['host'],
 				$config['username'],
-				$config['password'],
+				$config['password'] ?? '',
 				$config['database'] ?? '',
 				$config['port'] ?? 0,
 				$config['socket'],


### PR DESCRIPTION
mysqli::real_connect() expects parameter 3 to be string, yields an error on NULL.

- bug fix
- not a BC break