### PR TITLE
Extension: Automatic registration of static connection for back compatibility

### DIFF
--- a/src/Dibi/Bridges/Nette/DibiExtension22.php
+++ b/src/Dibi/Bridges/Nette/DibiExtension22.php
@@ -68,5 +68,8 @@ class DibiExtension22 extends Nette\DI\CompilerExtension
 				]);
 			$connection->addSetup([$panel, 'register'], [$connection]);
 		}
+		if ($config['staticConnection'] ?? false) {
+			$connection->addSetup(new Nette\DI\Statement('\dibi::setConnection'));
+		}
 	}
 }


### PR DESCRIPTION
- new feature
- BC break? no

When I want migrate old project to DIC, first I should fix all dependencies.

This suggestion can help configuration and remove redundant code lines in configuration.

Thanks.