### PR TITLE
Postgre driver - add connect_type config parameter

### DIFF
--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -50,6 +50,8 @@ class PostgreDriver implements Dibi\Driver
 			$config += [
 				'charset' => 'utf8',
 			];
+			if (!isset($config['connect_type']))
+				$config['connect_type'] = PGSQL_CONNECT_FORCE_NEW;
 			if (isset($config['string'])) {
 				$string = $config['string'];
 			} else {
@@ -67,9 +69,9 @@ class PostgreDriver implements Dibi\Driver
 				$error = $message;
 			});
 			if (empty($config['persistent'])) {
-				$this->connection = pg_connect($string, PGSQL_CONNECT_FORCE_NEW);
+				$this->connection = pg_connect($string, $config['connect_type']);
 			} else {
-				$this->connection = pg_pconnect($string);
+				$this->connection = pg_pconnect($string, $config['connect_type']);
 			}
 			restore_error_handler();
 		}

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -50,8 +50,9 @@ class PostgreDriver implements Dibi\Driver
 			$config += [
 				'charset' => 'utf8',
 			];
-			if (!isset($config['connect_type']))
+			if (!isset($config['connect_type'])) {
 				$config['connect_type'] = PGSQL_CONNECT_FORCE_NEW;
+			}
 			if (isset($config['string'])) {
 				$string = $config['string'];
 			} else {

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -72,7 +72,7 @@ class PostgreDriver implements Dibi\Driver
 			if (empty($config['persistent'])) {
 				$this->connection = pg_connect($string, $config['connect_type']);
 			} else {
-				$this->connection = pg_pconnect($string, $config['connect_type']);
+				$this->connection = pg_pconnect($string);
 			}
 			restore_error_handler();
 		}


### PR DESCRIPTION
 - adds the option to pass the connect_type as config parameter
 - PHP default is 0, but to make this change non-breaking defauls to PGSQL_CONNECT_FORCE_NEW
 - see PHP docs: https://www.php.net/manual/en/function.pg-connect.php

- new approach to issue #353
- BC break? no