### PR TITLE
Tracy\Panel: fixed object to string converion error with custom driver

### DIFF
--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -143,7 +143,7 @@ class Panel implements Tracy\IBarPanel
 			#tracy-debug tracy-DibiProfiler tr table { margin: 8px 0; max-height: 150px; overflow:auto } </style>
 			<h1>Queries: ' . count($this->events)
 				. ($totalTime === null ? '' : ', time: ' . number_format($totalTime * 1000, 1, '.', ' ') . ' ms') . ', '
-				. htmlspecialchars($connection->getConfig('driver') . ($connection->getConfig('name') ? '/' . $connection->getConfig('name') : '')
+				. htmlspecialchars((is_object($driver = $connection->getConfig('driver')) ? get_class($driver) : $driver) . ($connection->getConfig('name') ? '/' . $connection->getConfig('name') : '')
 				. ($connection->getConfig('host') ? ' @ ' . $connection->getConfig('host') : '')) . '</h1>
 			<div class="tracy-inner tracy-DibiProfiler">
 			<table>


### PR DESCRIPTION
- bug fix
- BC break? no

With a custom driver, Tracy panel failed to render with message `Object ... could not be converted to string`