### PR TITLE
FileLogger: fixed object to string conversion with custom driver

### DIFF
--- a/src/Dibi/Loggers/FileLogger.php
+++ b/src/Dibi/Loggers/FileLogger.php
@@ -74,7 +74,7 @@ class FileLogger
 	private function writeToFile(Dibi\Event $event, string $message): void
 	{
 		$message .=
-			"\n-- driver: " . $event->connection->getConfig('driver') . '/' . $event->connection->getConfig('name')
+			"\n-- driver: " . (is_object($driver = $event->connection->getConfig('driver')) ? get_class($driver) : $driver) . '/' . $event->connection->getConfig('name')
 			. "\n-- " . date('Y-m-d H:i:s')
 			. "\n\n";
 		file_put_contents($this->file, $message, FILE_APPEND | LOCK_EX);


### PR DESCRIPTION
- bug fix
- BC break? no

Same as #373 and I hope I already found all places.