### PR TITLE
Dibi/Helpers::getSuggestion(): item may be an int, type cast fix

### DIFF
--- a/src/Dibi/Helpers.php
+++ b/src/Dibi/Helpers.php
@@ -144,7 +144,7 @@ class Helpers
 		$best = null;
 		$min = (strlen($value) / 4 + 1) * 10 + .1;
 		foreach (array_unique($items, SORT_REGULAR) as $item) {
-			$item = is_object($item) ? $item->getName() : $item;
+			$item = is_object($item) ? $item->getName() : (string) $item;
 			if (($len = levenshtein($item, $value, 10, 11, 10)) > 0 && $len < $min) {
 				$min = $len;
 				$best = $item;


### PR DESCRIPTION
- bug fix - yes
- BC break? no

Dibi/Helpers::getSuggestion(): item may be an int, type cast fix, query example:

SELECT 1 FROM `users`