### PR TITLE
PostgreReflector: removed version check

### DIFF
--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -28,9 +28,6 @@ class PostgreReflector implements Dibi\Reflector
 
 	public function __construct(Dibi\Driver $driver, string $version)
 	{
-		if ($version < 7.4) {
-			throw new Dibi\DriverException('Reflection requires PostgreSQL 7.4 and newer.');
-		}
 		$this->driver = $driver;
 		$this->version = $version;
 	}


### PR DESCRIPTION
- bug fix #380 
- BC break? no

As comparing string and number has changed and PostgreSQL version 7.4 is outdated (~year 2003), I have removed the check altogether. @dg are you OK with that?