### PR TITLE
Nested trasactions

### DIFF
--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -329,6 +329,10 @@ class Connection implements IConnection
 	 */
 	public function begin(string $savepoint = null): void
 	{
+		if ($this->transactionDepth !== 0) {
+			throw new \LogicException(__METHOD__ . '() call is forbidden inside a transaction() callback');
+		}
+
 		if (!$this->driver) {
 			$this->connect();
 		}
@@ -353,6 +357,10 @@ class Connection implements IConnection
 	 */
 	public function commit(string $savepoint = null): void
 	{
+		if ($this->transactionDepth !== 0) {
+			throw new \LogicException(__METHOD__ . '() call is forbidden inside a transaction() callback');
+		}
+
 		if (!$this->driver) {
 			$this->connect();
 		}
@@ -377,6 +385,10 @@ class Connection implements IConnection
 	 */
 	public function rollback(string $savepoint = null): void
 	{
+		if ($this->transactionDepth !== 0) {
+			throw new \LogicException(__METHOD__ . '() call is forbidden inside a transaction() callback');
+		}
+
 		if (!$this->driver) {
 			$this->connect();
 		}

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -398,7 +398,7 @@ class Connection implements IConnection
 	{
 		$this->begin();
 		try {
-			$res = $callback();
+			$res = $callback($this);
 		} catch (\Throwable $e) {
 			$this->rollback();
 			throw $e;

--- a/src/Dibi/Event.php
+++ b/src/Dibi/Event.php
@@ -54,7 +54,7 @@ class Event
 		$this->time = -microtime(true);
 
 		if ($type === self::QUERY && preg_match('#\(?\s*(SELECT|UPDATE|INSERT|DELETE)#iA', $this->sql, $matches)) {
-			static array $types = [
+			static $types = [
 				'SELECT' => self::SELECT, 'UPDATE' => self::UPDATE,
 				'INSERT' => self::INSERT, 'DELETE' => self::DELETE,
 			];

--- a/src/Dibi/dibi.php
+++ b/src/Dibi/dibi.php
@@ -59,7 +59,7 @@ class dibi
 	public static ?float $elapsedTime = null;
 
 	/** Elapsed time for all queries */
-	public static float $totalTime;
+	public static float $totalTime = 0;
 
 	/** Number or queries */
 	public static int $numOfQueries = 0;

--- a/tests/dibi/Connection.transactions.phpt
+++ b/tests/dibi/Connection.transactions.phpt
@@ -52,8 +52,8 @@ Assert::same(4, (int) $conn->query('SELECT COUNT(*) FROM [products]')->fetchSing
 
 
 Assert::exception(function () use ($conn) {
-	$conn->transaction(function () use ($conn) {
-		$conn->query('INSERT INTO [products]', [
+	$conn->transaction(function (Dibi\Connection $connection) {
+		$connection->query('INSERT INTO [products]', [
 			'title' => 'Test product',
 		]);
 		throw new Exception('my exception');
@@ -62,8 +62,8 @@ Assert::exception(function () use ($conn) {
 
 Assert::same(4, (int) $conn->query('SELECT COUNT(*) FROM [products]')->fetchSingle());
 
-$conn->transaction(function () use ($conn) {
-	$conn->query('INSERT INTO [products]', [
+$conn->transaction(function (Dibi\Connection $connection) {
+	$connection->query('INSERT INTO [products]', [
 		'title' => 'Test product',
 	]);
 });

--- a/tests/dibi/Connection.transactions.phpt
+++ b/tests/dibi/Connection.transactions.phpt
@@ -108,3 +108,24 @@ test('nested transaction() call success', function () use ($conn) {
 	});
 	Assert::same(7, (int) $conn->query('SELECT COUNT(*) FROM [products]')->fetchSingle());
 });
+
+
+test('begin(), commit() & rollback() calls are forbidden in transaction()', function () use ($conn) {
+	Assert::exception(function () use ($conn) {
+		$conn->transaction(function (Dibi\Connection $connection) {
+			$connection->begin();
+		});
+	}, \LogicException::class, Dibi\Connection::class . '::begin() call is forbidden inside a transaction() callback');
+
+	Assert::exception(function () use ($conn) {
+		$conn->transaction(function (Dibi\Connection $connection) {
+			$connection->commit();
+		});
+	}, \LogicException::class, Dibi\Connection::class . '::commit() call is forbidden inside a transaction() callback');
+
+	Assert::exception(function () use ($conn) {
+		$conn->transaction(function (Dibi\Connection $connection) {
+			$connection->rollback();
+		});
+	}, \LogicException::class, Dibi\Connection::class . '::rollback() call is forbidden inside a transaction() callback');
+});

--- a/tests/dibi/Result.meta.phpt
+++ b/tests/dibi/Result.meta.phpt
@@ -32,7 +32,7 @@ Assert::same(
 );
 
 
-if (!in_array($config['driver'], ['sqlite', 'pdo', 'sqlsrv'], true)) {
+if (!in_array($config['driver'], ['sqlite', 'sqlite3', 'pdo', 'sqlsrv'], true)) {
 	Assert::same(
 		['products.product_id', 'orders.order_id', 'customers.name', 'xXx'],
 		$info->getColumnNames(true),
@@ -43,7 +43,7 @@ if (!in_array($config['driver'], ['sqlite', 'pdo', 'sqlsrv'], true)) {
 $columns = $info->getColumns();
 
 Assert::same('product_id', $columns[0]->getName());
-if (!in_array($config['driver'], ['sqlite', 'pdo', 'sqlsrv'], true)) {
+if (!in_array($config['driver'], ['sqlite', 'sqlite3', 'pdo', 'sqlsrv'], true)) {
 	Assert::same('products', $columns[0]->getTableName());
 }
 Assert::null($columns[0]->getVendorInfo('xxx'));


### PR DESCRIPTION
- bug fixes & new feature
- BC break? no

First commits are some fixes, but main purpose of this PR is to allow nested `Connection::transaction()` calls. For example, this is useful if you have dependent repositories and in one you call:
```php
public function savePerson($data)
{
    $this->db->transaction(function () {...});
}
```
and in other one
```php
public function save()
{
    $this->db->transaction(function ($db) {
        $this->repo1->savePerson(...);
        $this->repo2->saveMoney(...);
        $this->repo3->saveAddresses(...);
        $db->query('UPDATE ....');
    });
}
```
I'm already using this concept more than 5 years and never hit any problem.

One note to implementation: nesting can be implemented in the `begin()`, `commit()` and `rollback()` methods but it brings some questions in an user code. Imagine this:
```php
$this->db->begin();
try {
    $this->db->query();
    $this->db->commit();  # well, in nested transaction, COMMIT was not really called
    ... you think data are commited and you do something
} catch (Exception $e) {
    $this->db->rollback();
}
```
That's why I prefer `transaction()` API or `begin/commit/rollback()` API, but not simultaneously.

Some future thoughts:
- some commit hook should be provided to the callback, so some action can be done when transaction is really commited
- automatic way to repeating failed transaction - provide an API for some kind of transaction arbitrator

Both of this can be probably implemented via some new `Transaction` object created on `BEGIN` call. It is idea only for now.