### PR TITLE
PDO: Support for PDO::ERRMODE_EXCEPTION

### DIFF
--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -17,16 +17,14 @@ function buildPdoDriver(?int $errorMode)
 }
 
 
-// PDO error mode: exception
-Assert::exception(function () {
-	buildPdoDriver(PDO::ERRMODE_EXCEPTION);
-}, Dibi\DriverException::class, 'PDO connection in exception or warning error mode is not supported.');
+// PDO error mode: exception is accepted
+buildPdoDriver(PDO::ERRMODE_EXCEPTION);
 
 
 // PDO error mode: warning
 Assert::exception(function () {
 	buildPdoDriver(PDO::ERRMODE_WARNING);
-}, Dibi\DriverException::class, 'PDO connection in exception or warning error mode is not supported.');
+}, Dibi\DriverException::class, 'PDO connection in warning error mode is not supported.');
 
 
 test('PDO error mode: explicitly set silent', function () {


### PR DESCRIPTION
- new feature, no existing code will break (full bc)

I added support for PDO in `PDO::ERRMODE_EXCEPTION` error mode using a single try-catch block.

👉 Since in PHP 8 `PDO::ERRMODE_EXCEPTION` is the default, this is also useful for your `master` branch.

> I have a use case where I need to share PDO resource and it's set with exception errmode, this solves the issue for the 4.2 branch.
