### PR TITLE
PDO: Support for PDO::ERRMODE_EXCEPTION (PHP8)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+                php: ['8.0', '8.1']
 
             fail-fast: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 build: off
 cache:
-    - c:\php7 -> appveyor.yml
+    - c:\php -> appveyor.yml
     - '%LOCALAPPDATA%\Composer\files -> appveyor.yml'
 
 clone_folder: c:\projects\dibi
@@ -11,21 +11,21 @@ services:
     - mysql
 
 init:
-    - SET PATH=c:\php7;%PATH%
+    - SET PATH=c:\php;%PATH%
     - SET ANSICON=121x90 (121x90)
 
 install:
-    # Install PHP 7.2
-    - IF EXIST c:\php7 (SET PHP=0) ELSE (SET PHP=1)
-    - IF %PHP%==1 mkdir c:\php7
-    - IF %PHP%==1 cd c:\php7
-    - IF %PHP%==1 curl https://windows.php.net/downloads/releases/archives/php-7.2.18-Win32-VC15-x64.zip --output php.zip
+    # Install PHP 8.0
+    - IF EXIST c:\php (SET PHP=0) ELSE (SET PHP=1)
+    - IF %PHP%==1 mkdir c:\php
+    - IF %PHP%==1 cd c:\php
+    - IF %PHP%==1 curl https://windows.php.net/downloads/releases/archives/php-8.0.1-Win32-vs16-x64.zip --output php.zip
     - IF %PHP%==1 7z x php.zip >nul
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
     - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-    - IF %PHP%==1 curl https://github.com/microsoft/msphpsql/releases/download/v5.8.0/Windows-7.2.zip -L --output sqlsrv.zip
+    - IF %PHP%==1 curl https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Windows-8.0.zip -L --output sqlsrv.zip
     - IF %PHP%==1 7z x sqlsrv.zip >nul
-    - IF %PHP%==1 copy Windows-7.2\x64\php_sqlsrv_72_ts.dll ext\php_sqlsrv_ts.dll
+    - IF %PHP%==1 copy Windows-8.0\x64\php_sqlsrv_80_ts.dll ext\php_sqlsrv_ts.dll
     - IF %PHP%==1 del /Q *.zip
 
     # Install Microsoft Access Database Engine x64
@@ -41,7 +41,7 @@ install:
     - copy tests\databases.appveyor.ini tests\databases.ini
 
 test_script:
-    - vendor\bin\tester tests -s -p c:\php7\php -c tests\php-win.ini
+    - vendor\bin\tester tests -s -p c:\php\php -c tests\php-win.ini
 
 on_failure:
     # Print *.actual content

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.2-dev"
+			"dev-master": "5.0-dev"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2"
+		"php": ">=8.0 <8.2"
 	},
 	"require-dev": {
 		"tracy/tracy": "~2.2",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"php": ">=8.0 <8.2"
 	},
 	"require-dev": {
-		"tracy/tracy": "~2.2",
-		"nette/tester": "~2.0",
+		"tracy/tracy": "^2.8",
+		"nette/tester": "^2.4",
 		"nette/di": "^3.0",
 		"phpstan/phpstan": "^0.12"
 	},

--- a/examples/query-language-and-conditions.php
+++ b/examples/query-language-and-conditions.php
@@ -31,7 +31,7 @@ $name = $cond1 ? 'K%' : null;
 $dibi->test('
 	SELECT *
 	FROM customers
-	%if', isset($name), 'WHERE name LIKE ?', $name, '%end'
+	%if', isset($name), 'WHERE name LIKE ?', $name, '%end',
 );
 // -> SELECT * FROM customers WHERE name LIKE 'K%'
 
@@ -54,7 +54,7 @@ $dibi->test('
 	WHERE
 		%if', isset($name), 'name LIKE ?', $name, '
 			%if', $cond2, 'AND admin=1 %end
-		%else 1 LIMIT 10 %end'
+		%else 1 LIMIT 10 %end',
 );
 // -> SELECT * FROM customers WHERE LIMIT 10
 

--- a/examples/query-language-basic-examples.php
+++ b/examples/query-language-basic-examples.php
@@ -28,7 +28,7 @@ $dibi->test('
 	SELECT COUNT(*) as [count]
 	FROM [comments]
 	WHERE [ip] LIKE ?', $ipMask, '
-	AND [date] > ', new Dibi\DateTime($timestamp)
+	AND [date] > ', new Dibi\DateTime($timestamp),
 );
 // -> SELECT COUNT(*) as [count] FROM [comments] WHERE [ip] LIKE '192.168.%' AND [date] > 876693600
 
@@ -69,7 +69,7 @@ $array = [1, 2, 3];
 $dibi->test('
 	SELECT *
 	FROM people
-	WHERE id IN (?)', $array
+	WHERE id IN (?)', $array,
 );
 // -> SELECT * FROM people WHERE id IN ( 1, 2, 3 )
 

--- a/examples/using-datetime.php
+++ b/examples/using-datetime.php
@@ -29,6 +29,6 @@ $dibi->test('
 		'id' => 123,
 		'date' => new DateTime('12.3.2007'),
 		'stamp' => new DateTime('23.1.2007 10:23'),
-	]
+	],
 );
 // -> INSERT INTO [mytable] ([id], [date], [stamp]) VALUES (123, '2007-03-12', '2007-01-23 10-23-00')

--- a/examples/using-substitutions.php
+++ b/examples/using-substitutions.php
@@ -54,6 +54,6 @@ define('SUBST_ACTIVE', 7);
 $dibi->test("
 	UPDATE :account:user
 	SET name='John Doe', status=:active:
-	WHERE id=", 7
+	WHERE id=", 7,
 );
 // -> UPDATE eshop_user SET name='John Doe', status=7 WHERE id= 7

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Install Dibi via Composer:
 composer require dibi/dibi
 ```
 
-The Dibi 4.2 requires PHP version 7.2 and supports PHP up to 8.1.
+The Dibi 5.0 requires PHP version 8.0 and supports PHP up to 8.1.
 
 
 Usage

--- a/src/Dibi/Bridges/Nette/DibiExtension22.php
+++ b/src/Dibi/Bridges/Nette/DibiExtension22.php
@@ -19,11 +19,9 @@ use Tracy;
  */
 class DibiExtension22 extends Nette\DI\CompilerExtension
 {
-	/** @var bool|null */
-	private $debugMode;
+	private ?bool $debugMode;
 
-	/** @var bool|null */
-	private $cliMode;
+	private ?bool $cliMode;
 
 
 	public function __construct(?bool $debugMode = null, ?bool $cliMode = null)

--- a/src/Dibi/Bridges/Nette/DibiExtension22.php
+++ b/src/Dibi/Bridges/Nette/DibiExtension22.php
@@ -66,7 +66,7 @@ class DibiExtension22 extends Nette\DI\CompilerExtension
 		if (class_exists(Tracy\Debugger::class)) {
 			$connection->addSetup(
 				[new Nette\DI\Statement('Tracy\Debugger::getBlueScreen'), 'addPanel'],
-				[[Dibi\Bridges\Tracy\Panel::class, 'renderException']]
+				[[Dibi\Bridges\Tracy\Panel::class, 'renderException']],
 			);
 		}
 

--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -32,7 +32,7 @@ class Panel implements Tracy\IBarPanel
 	private array $events = [];
 
 
-	public function __construct($explain = true, ?int $filter = null)
+	public function __construct(bool $explain = true, ?int $filter = null)
 	{
 		$this->filter = $filter ?: Event::QUERY;
 		$this->explain = $explain;

--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -174,7 +174,7 @@ class Panel implements Tracy\IBarPanel
 	private function getConnectionName(Dibi\Connection $connection): string
 	{
 		$driver = $connection->getConfig('driver');
-		return (is_object($driver) ? get_class($driver) : $driver)
+		return (is_object($driver) ? $driver::class : $driver)
 			. ($connection->getConfig('name') ? '/' . $connection->getConfig('name') : '')
 			. ($connection->getConfig('host') ? "\u{202f}@\u{202f}" . $connection->getConfig('host') : '');
 	}

--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -22,17 +22,14 @@ class Panel implements Tracy\IBarPanel
 {
 	use Dibi\Strict;
 
-	/** @var int maximum SQL length */
-	public static $maxLength = 1000;
+	/** maximum SQL length */
+	public static int $maxLength = 1000;
 
-	/** @var bool|string  explain queries? */
-	public $explain;
+	public bool|string $explain;
 
-	/** @var int */
-	public $filter;
+	public int $filter;
 
-	/** @var array */
-	private $events = [];
+	private array $events = [];
 
 
 	public function __construct($explain = true, ?int $filter = null)

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -75,7 +75,7 @@ class Connection implements IConnection
 		Helpers::alias($config, 'host', 'hostname');
 		Helpers::alias($config, 'result|formatDate', 'resultDate');
 		Helpers::alias($config, 'result|formatDateTime', 'resultDateTime');
-		$config['driver'] = $config['driver'] ?? 'mysqli';
+		$config['driver'] ??= 'mysqli';
 		$config['name'] = $name;
 		$this->config = $config;
 
@@ -93,7 +93,7 @@ class Connection implements IConnection
 			$this->onEvent[] = [new Loggers\FileLogger($config['profiler']['file'], $filter, $errorsOnly), 'logEvent'];
 		}
 
-		$this->substitutes = new HashMap(function (string $expr) { return ":$expr:"; });
+		$this->substitutes = new HashMap(fn(string $expr) => ":$expr:");
 		if (!empty($config['substitutes'])) {
 			foreach ($config['substitutes'] as $key => $value) {
 				$this->substitutes->$key = $value;
@@ -253,7 +253,7 @@ class Connection implements IConnection
 			if ($e->getSql()) {
 				Helpers::dump($e->getSql());
 			} else {
-				echo get_class($e) . ': ' . $e->getMessage() . (PHP_SAPI === 'cli' ? "\n" : '<br>');
+				echo $e::class . ': ' . $e->getMessage() . (PHP_SAPI === 'cli' ? "\n" : '<br>');
 			}
 
 			return false;
@@ -529,7 +529,7 @@ class Connection implements IConnection
 	{
 		return strpos($value, ':') === false
 			? $value
-			: preg_replace_callback('#:([^:\s]*):#', function (array $m) { return $this->substitutes->{$m[1]}; }, $value);
+			: preg_replace_callback('#:([^:\s]*):#', fn(array $m) => $this->substitutes->{$m[1]}, $value);
 	}
 
 

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -516,9 +516,9 @@ class Connection implements IConnection
 	 */
 	public function substitute(string $value): string
 	{
-		return strpos($value, ':') === false
-			? $value
-			: preg_replace_callback('#:([^:\s]*):#', fn(array $m) => $this->substitutes->{$m[1]}, $value);
+		return str_contains($value, ':')
+			? preg_replace_callback('#:([^:\s]*):#', fn(array $m) => $this->substitutes->{$m[1]}, $value)
+			: $value;
 	}
 
 

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -187,9 +187,8 @@ class Connection implements IConnection
 	/**
 	 * Returns configuration variable. If no $key is passed, returns the entire array.
 	 * @see self::__construct
-	 * @return mixed
 	 */
-	final public function getConfig(?string $key = null, $default = null)
+	final public function getConfig(?string $key = null, $default = null): mixed
 	{
 		return $key === null
 			? $this->config
@@ -212,10 +211,9 @@ class Connection implements IConnection
 
 	/**
 	 * Generates (translates) and executes SQL query.
-	 * @param  mixed  ...$args
 	 * @throws Exception
 	 */
-	final public function query(...$args): Result
+	final public function query(mixed ...$args): Result
 	{
 		return $this->nativeQuery($this->translate(...$args));
 	}
@@ -223,10 +221,9 @@ class Connection implements IConnection
 
 	/**
 	 * Generates SQL query.
-	 * @param  mixed  ...$args
 	 * @throws Exception
 	 */
-	final public function translate(...$args): string
+	final public function translate(mixed ...$args): string
 	{
 		if (!$this->driver) {
 			$this->connect();
@@ -238,9 +235,8 @@ class Connection implements IConnection
 
 	/**
 	 * Generates and prints SQL query.
-	 * @param  mixed  ...$args
 	 */
-	final public function test(...$args): bool
+	final public function test(mixed ...$args): bool
 	{
 		try {
 			Helpers::dump($this->translate(...$args));
@@ -260,10 +256,9 @@ class Connection implements IConnection
 
 	/**
 	 * Generates (translates) and returns SQL query as DataSource.
-	 * @param  mixed  ...$args
 	 * @throws Exception
 	 */
-	final public function dataSource(...$args): DataSource
+	final public function dataSource(mixed ...$args): DataSource
 	{
 		return new DataSource($this->translate(...$args), $this);
 	}
@@ -426,10 +421,7 @@ class Connection implements IConnection
 	}
 
 
-	/**
-	 * @return mixed
-	 */
-	public function transaction(callable $callback)
+	public function transaction(callable $callback): mixed
 	{
 		if ($this->transactionDepth === 0) {
 			$this->begin();
@@ -535,10 +527,9 @@ class Connection implements IConnection
 
 	/**
 	 * Executes SQL query and fetch result - shortcut for query() & fetch().
-	 * @param  mixed  ...$args
 	 * @throws Exception
 	 */
-	public function fetch(...$args): ?Row
+	public function fetch(mixed ...$args): ?Row
 	{
 		return $this->query($args)->fetch();
 	}
@@ -546,11 +537,10 @@ class Connection implements IConnection
 
 	/**
 	 * Executes SQL query and fetch results - shortcut for query() & fetchAll().
-	 * @param  mixed  ...$args
 	 * @return Row[]|array[]
 	 * @throws Exception
 	 */
-	public function fetchAll(...$args): array
+	public function fetchAll(mixed ...$args): array
 	{
 		return $this->query($args)->fetchAll();
 	}
@@ -558,11 +548,9 @@ class Connection implements IConnection
 
 	/**
 	 * Executes SQL query and fetch first column - shortcut for query() & fetchSingle().
-	 * @param  mixed  ...$args
-	 * @return mixed
 	 * @throws Exception
 	 */
-	public function fetchSingle(...$args)
+	public function fetchSingle(mixed ...$args): mixed
 	{
 		return $this->query($args)->fetchSingle();
 	}
@@ -570,10 +558,9 @@ class Connection implements IConnection
 
 	/**
 	 * Executes SQL query and fetch pairs - shortcut for query() & fetchPairs().
-	 * @param  mixed  ...$args
 	 * @throws Exception
 	 */
-	public function fetchPairs(...$args): array
+	public function fetchPairs(mixed ...$args): array
 	{
 		return $this->query($args)->fetchPairs();
 	}

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -22,25 +22,22 @@ class Connection implements IConnection
 {
 	use Strict;
 
-	/** @var array of function (Event $event); Occurs after query is executed */
-	public $onEvent = [];
+	/** function (Event $event); Occurs after query is executed */
+	public array $onEvent = [];
 
-	/** @var array  Current connection configuration */
-	private $config;
+	/** Current connection configuration */
+	private array $config;
 
 	/** @var string[]  resultset formats */
-	private $formats;
+	private array $formats;
 
-	/** @var Driver|null */
-	private $driver;
+	private ?Driver $driver = null;
 
-	/** @var Translator|null */
-	private $translator;
+	private ?Translator $translator = null;
 
-	/** @var HashMap Substitutes for identifiers */
-	private $substitutes;
+	private HashMap $substitutes;
 
-	private $transactionDepth = 0;
+	private int $transactionDepth = 0;
 
 
 	/**

--- a/src/Dibi/DataSource.php
+++ b/src/Dibi/DataSource.php
@@ -55,7 +55,7 @@ class DataSource implements IDataSource
 	 * @param  string|array  $col  column name or array of column names
 	 * @param  string  $as        column alias
 	 */
-	public function select($col, ?string $as = null): self
+	public function select(string|array $col, ?string $as = null): static
 	{
 		if (is_array($col)) {
 			$this->cols = $col;
@@ -71,7 +71,7 @@ class DataSource implements IDataSource
 	/**
 	 * Adds conditions to query.
 	 */
-	public function where($cond): self
+	public function where($cond): static
 	{
 		$this->conds[] = is_array($cond)
 			? $cond // TODO: not consistent with select and orderBy
@@ -85,7 +85,7 @@ class DataSource implements IDataSource
 	 * Selects columns to order by.
 	 * @param  string|array  $row  column name or array of column names
 	 */
-	public function orderBy($row, string $direction = 'ASC'): self
+	public function orderBy(string|array $row, string $direction = 'ASC'): static
 	{
 		if (is_array($row)) {
 			$this->sorting = $row;
@@ -101,7 +101,7 @@ class DataSource implements IDataSource
 	/**
 	 * Limits number of rows.
 	 */
-	public function applyLimit(int $limit, ?int $offset = null): self
+	public function applyLimit(int $limit, ?int $offset = null): static
 	{
 		$this->limit = $limit;
 		$this->offset = $offset;
@@ -151,7 +151,7 @@ class DataSource implements IDataSource
 	 * Like fetch(), but returns only first field.
 	 * @return mixed  value on success, null if no next record
 	 */
-	public function fetchSingle()
+	public function fetchSingle(): mixed
 	{
 		return $this->getResult()->fetchSingle();
 	}

--- a/src/Dibi/DataSource.php
+++ b/src/Dibi/DataSource.php
@@ -17,35 +17,25 @@ class DataSource implements IDataSource
 {
 	use Strict;
 
-	/** @var Connection */
-	private $connection;
+	private Connection $connection;
 
-	/** @var string */
-	private $sql;
+	private string $sql;
 
-	/** @var Result|null */
-	private $result;
+	private ?Result $result = null;
 
-	/** @var int|null */
-	private $count;
+	private ?int $count = null;
 
-	/** @var int|null */
-	private $totalCount;
+	private ?int $totalCount = null;
 
-	/** @var array */
-	private $cols = [];
+	private array $cols = [];
 
-	/** @var array */
-	private $sorting = [];
+	private array $sorting = [];
 
-	/** @var array */
-	private $conds = [];
+	private array $conds = [];
 
-	/** @var int|null */
-	private $offset;
+	private ?int $offset = null;
 
-	/** @var int|null */
-	private $limit;
+	private ?int $limit = null;
 
 
 	/**

--- a/src/Dibi/DataSource.php
+++ b/src/Dibi/DataSource.php
@@ -241,7 +241,7 @@ class DataSource implements IDataSource
 				$this->sorting ? ['ORDER BY %by', $this->sorting] : null,
 				"\n%ofs %lmt",
 				$this->offset,
-				$this->limit
+				$this->limit,
 			);
 		} catch (\Throwable $e) {
 			trigger_error($e->getMessage(), E_USER_ERROR);
@@ -261,7 +261,7 @@ class DataSource implements IDataSource
 		if ($this->count === null) {
 			$this->count = $this->conds || $this->offset || $this->limit
 				? Helpers::intVal($this->connection->nativeQuery(
-					'SELECT COUNT(*) FROM (' . $this->__toString() . ') t'
+					'SELECT COUNT(*) FROM (' . $this->__toString() . ') t',
 				)->fetchSingle())
 				: $this->getTotalCount();
 		}
@@ -277,7 +277,7 @@ class DataSource implements IDataSource
 	{
 		if ($this->totalCount === null) {
 			$this->totalCount = Helpers::intVal($this->connection->nativeQuery(
-				'SELECT COUNT(*) FROM ' . $this->sql
+				'SELECT COUNT(*) FROM ' . $this->sql,
 			)->fetchSingle());
 		}
 

--- a/src/Dibi/DataSource.php
+++ b/src/Dibi/DataSource.php
@@ -229,24 +229,19 @@ class DataSource implements IDataSource
 	 */
 	public function __toString(): string
 	{
-		try {
-			return $this->connection->translate(
-				"\nSELECT %n",
-				(empty($this->cols) ? '*' : $this->cols),
-				"\nFROM %SQL",
-				$this->sql,
-				"\n%ex",
-				$this->conds ? ['WHERE %and', $this->conds] : null,
-				"\n%ex",
-				$this->sorting ? ['ORDER BY %by', $this->sorting] : null,
-				"\n%ofs %lmt",
-				$this->offset,
-				$this->limit,
-			);
-		} catch (\Throwable $e) {
-			trigger_error($e->getMessage(), E_USER_ERROR);
-			return '';
-		}
+		return $this->connection->translate(
+			"\nSELECT %n",
+			(empty($this->cols) ? '*' : $this->cols),
+			"\nFROM %SQL",
+			$this->sql,
+			"\n%ex",
+			$this->conds ? ['WHERE %and', $this->conds] : null,
+			"\n%ex",
+			$this->sorting ? ['ORDER BY %by', $this->sorting] : null,
+			"\n%ofs %lmt",
+			$this->offset,
+			$this->limit,
+		);
 	}
 
 

--- a/src/Dibi/DateTime.php
+++ b/src/Dibi/DateTime.php
@@ -17,10 +17,7 @@ class DateTime extends \DateTimeImmutable
 {
 	use Strict;
 
-	/**
-	 * @param  string|int  $time
-	 */
-	public function __construct($time = 'now', ?\DateTimeZone $timezone = null)
+	public function __construct(string|int $time = 'now', ?\DateTimeZone $timezone = null)
 	{
 		$timezone = $timezone ?: new \DateTimeZone(date_default_timezone_get());
 		if (is_numeric($time)) {

--- a/src/Dibi/Drivers/DummyDriver.php
+++ b/src/Dibi/Drivers/DummyDriver.php
@@ -57,7 +57,7 @@ class DummyDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 	}
 
 
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return null;
 	}
@@ -171,8 +171,9 @@ class DummyDriver implements Dibi\Driver, Dibi\ResultDriver, Dibi\Reflector
 	}
 
 
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
+		return null;
 	}
 
 

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -33,11 +33,10 @@ class FirebirdDriver implements Dibi\Driver
 	/** @var resource */
 	private $connection;
 
-	/** @var resource|null */
+	/** @var ?resource */
 	private $transaction;
 
-	/** @var bool */
-	private $inTransaction = false;
+	private bool $inTransaction = false;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/FirebirdDriver.php
+++ b/src/Dibi/Drivers/FirebirdDriver.php
@@ -190,7 +190,7 @@ class FirebirdDriver implements Dibi\Driver
 	 * Returns the connection resource.
 	 * @return resource|null
 	 */
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return is_resource($this->connection) ? $this->connection : null;
 	}

--- a/src/Dibi/Drivers/FirebirdReflector.php
+++ b/src/Dibi/Drivers/FirebirdReflector.php
@@ -19,8 +19,7 @@ class FirebirdReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/FirebirdReflector.php
+++ b/src/Dibi/Drivers/FirebirdReflector.php
@@ -242,7 +242,7 @@ class FirebirdReflector implements Dibi\Reflector
 				END AS TRIGGER_ENABLED
 			FROM RDB\$TRIGGERS
 			WHERE RDB\$SYSTEM_FLAG = 0"
-			. ($table === null ? ';' : " AND RDB\$RELATION_NAME = UPPER('$table');")
+			. ($table === null ? ';' : " AND RDB\$RELATION_NAME = UPPER('$table');"),
 		);
 		$triggers = [];
 		while ($row = $res->fetch(true)) {

--- a/src/Dibi/Drivers/FirebirdResult.php
+++ b/src/Dibi/Drivers/FirebirdResult.php
@@ -23,8 +23,7 @@ class FirebirdResult implements Dibi\ResultDriver
 	/** @var resource */
 	private $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
 
 	/**

--- a/src/Dibi/Drivers/FirebirdResult.php
+++ b/src/Dibi/Drivers/FirebirdResult.php
@@ -102,7 +102,7 @@ class FirebirdResult implements Dibi\ResultDriver
 	 * Returns the result set resource.
 	 * @return resource|null
 	 */
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		$this->autoFree = false;
 		return is_resource($this->resultSet) ? $this->resultSet : null;

--- a/src/Dibi/Drivers/MySqlReflector.php
+++ b/src/Dibi/Drivers/MySqlReflector.php
@@ -20,8 +20,7 @@ class MySqlReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -158,10 +158,7 @@ class MySqliDriver implements Dibi\Driver
 	}
 
 
-	/**
-	 * @param int|string $code
-	 */
-	public static function createException(string $message, $code, string $sql): Dibi\DriverException
+	public static function createException(string $message, int|string $code, string $sql): Dibi\DriverException
 	{
 		if (in_array($code, [1216, 1217, 1451, 1452, 1701], true)) {
 			return new Dibi\ForeignKeyConstraintViolationException($message, $code, $sql);

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -40,11 +40,10 @@ class MySqliDriver implements Dibi\Driver
 
 	public const ERROR_DATA_TRUNCATED = 1265;
 
-	/** @var \mysqli */
-	private $connection;
+	private \mysqli $connection;
 
-	/** @var bool  Is buffered (seekable and countable)? */
-	private $buffered;
+	/** Is buffered (seekable and countable)? */
+	private bool $buffered = false;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -96,7 +96,7 @@ class MySqliDriver implements Dibi\Driver
 				$config['database'] ?? '',
 				$config['port'] ?? 0,
 				$config['socket'],
-				$config['flags'] ?? 0
+				$config['flags'] ?? 0,
 			);
 
 			if ($this->connection->connect_errno) {

--- a/src/Dibi/Drivers/MySqliResult.php
+++ b/src/Dibi/Drivers/MySqliResult.php
@@ -19,14 +19,12 @@ class MySqliResult implements Dibi\ResultDriver
 {
 	use Dibi\Strict;
 
-	/** @var \mysqli_result */
-	private $resultSet;
+	private \mysqli_result $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
-	/** @var bool  Is buffered (seekable and countable)? */
-	private $buffered;
+	/** Is buffered (seekable and countable)? */
+	private bool $buffered;
 
 
 	public function __construct(\mysqli_result $resultSet, bool $buffered)

--- a/src/Dibi/Drivers/NoDataResult.php
+++ b/src/Dibi/Drivers/NoDataResult.php
@@ -19,8 +19,7 @@ class NoDataResult implements Dibi\ResultDriver
 {
 	use Dibi\Strict;
 
-	/** @var int */
-	private $rows;
+	private int $rows;
 
 
 	public function __construct(int $rows)

--- a/src/Dibi/Drivers/NoDataResult.php
+++ b/src/Dibi/Drivers/NoDataResult.php
@@ -60,7 +60,7 @@ class NoDataResult implements Dibi\ResultDriver
 	}
 
 
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		return null;
 	}

--- a/src/Dibi/Drivers/OdbcDriver.php
+++ b/src/Dibi/Drivers/OdbcDriver.php
@@ -170,7 +170,7 @@ class OdbcDriver implements Dibi\Driver
 	 * Returns the connection resource.
 	 * @return resource|null
 	 */
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return is_resource($this->connection) ? $this->connection : null;
 	}

--- a/src/Dibi/Drivers/OdbcDriver.php
+++ b/src/Dibi/Drivers/OdbcDriver.php
@@ -125,7 +125,7 @@ class OdbcDriver implements Dibi\Driver
 	 */
 	public function begin(?string $savepoint = null): void
 	{
-		if (!odbc_autocommit($this->connection, PHP_VERSION_ID < 80000 ? 0 : false)) {
+		if (!odbc_autocommit($this->connection, false)) {
 			throw new Dibi\DriverException(odbc_errormsg($this->connection) . ' ' . odbc_error($this->connection));
 		}
 	}
@@ -141,7 +141,7 @@ class OdbcDriver implements Dibi\Driver
 			throw new Dibi\DriverException(odbc_errormsg($this->connection) . ' ' . odbc_error($this->connection));
 		}
 
-		odbc_autocommit($this->connection, PHP_VERSION_ID < 80000 ? 1 : true);
+		odbc_autocommit($this->connection, true);
 	}
 
 
@@ -155,7 +155,7 @@ class OdbcDriver implements Dibi\Driver
 			throw new Dibi\DriverException(odbc_errormsg($this->connection) . ' ' . odbc_error($this->connection));
 		}
 
-		odbc_autocommit($this->connection, PHP_VERSION_ID < 80000 ? 1 : true);
+		odbc_autocommit($this->connection, true);
 	}
 
 

--- a/src/Dibi/Drivers/OdbcDriver.php
+++ b/src/Dibi/Drivers/OdbcDriver.php
@@ -30,11 +30,9 @@ class OdbcDriver implements Dibi\Driver
 	/** @var resource */
 	private $connection;
 
-	/** @var int|null  Affected rows */
-	private $affectedRows;
+	private ?int $affectedRows;
 
-	/** @var bool */
-	private $microseconds = true;
+	private bool $microseconds = true;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/OdbcReflector.php
+++ b/src/Dibi/Drivers/OdbcReflector.php
@@ -19,8 +19,7 @@ class OdbcReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/OdbcResult.php
+++ b/src/Dibi/Drivers/OdbcResult.php
@@ -125,7 +125,7 @@ class OdbcResult implements Dibi\ResultDriver
 	 * Returns the result set resource.
 	 * @return resource|null
 	 */
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		$this->autoFree = false;
 		return is_resource($this->resultSet) ? $this->resultSet : null;

--- a/src/Dibi/Drivers/OdbcResult.php
+++ b/src/Dibi/Drivers/OdbcResult.php
@@ -22,11 +22,9 @@ class OdbcResult implements Dibi\ResultDriver
 	/** @var resource */
 	private $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
-	/** @var int  Cursor */
-	private $row = 0;
+	private int $row = 0;
 
 
 	/**

--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -186,7 +186,7 @@ class OracleDriver implements Dibi\Driver
 	 * Returns the connection resource.
 	 * @return resource|null
 	 */
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return is_resource($this->connection) ? $this->connection : null;
 	}

--- a/src/Dibi/Drivers/OracleDriver.php
+++ b/src/Dibi/Drivers/OracleDriver.php
@@ -32,14 +32,12 @@ class OracleDriver implements Dibi\Driver
 	/** @var resource */
 	private $connection;
 
-	/** @var bool */
-	private $autocommit = true;
+	private bool $autocommit = true;
 
-	/** @var bool  use native datetime format */
-	private $nativeDate;
+	/** use native datetime format */
+	private bool $nativeDate;
 
-	/** @var int|null Number of affected rows */
-	private $affectedRows;
+	private ?int $affectedRows;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/OracleReflector.php
+++ b/src/Dibi/Drivers/OracleReflector.php
@@ -19,8 +19,7 @@ class OracleReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/OracleResult.php
+++ b/src/Dibi/Drivers/OracleResult.php
@@ -22,8 +22,7 @@ class OracleResult implements Dibi\ResultDriver
 	/** @var resource */
 	private $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
 
 	/**

--- a/src/Dibi/Drivers/OracleResult.php
+++ b/src/Dibi/Drivers/OracleResult.php
@@ -108,7 +108,7 @@ class OracleResult implements Dibi\ResultDriver
 	 * Returns the result set resource.
 	 * @return resource|null
 	 */
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		$this->autoFree = false;
 		return is_resource($this->resultSet) ? $this->resultSet : null;

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -29,17 +29,13 @@ class PdoDriver implements Dibi\Driver
 {
 	use Dibi\Strict;
 
-	/** @var PDO|null  Connection resource */
-	private $connection;
+	private ?PDO $connection;
 
-	/** @var int|null  Affected rows */
-	private $affectedRows;
+	private ?int $affectedRows;
 
-	/** @var string */
-	private $driverName;
+	private string $driverName;
 
-	/** @var string */
-	private $serverVersion = '';
+	private string $serverVersion = '';
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -12,6 +12,7 @@ namespace Dibi\Drivers;
 use Dibi;
 use Dibi\Helpers;
 use PDO;
+use PDOException;
 
 
 /**
@@ -53,8 +54,8 @@ class PdoDriver implements Dibi\Driver
 			$this->connection = $config['resource'];
 			unset($config['resource'], $config['pdo']);
 
-			if ($this->connection->getAttribute(PDO::ATTR_ERRMODE) !== PDO::ERRMODE_SILENT) {
-				throw new Dibi\DriverException('PDO connection in exception or warning error mode is not supported.');
+			if ($this->connection->getAttribute(PDO::ATTR_ERRMODE) === PDO::ERRMODE_WARNING) {
+				throw new Dibi\DriverException('PDO connection in warning error mode is not supported.');
 			}
 		} else {
 			try {
@@ -89,15 +90,18 @@ class PdoDriver implements Dibi\Driver
 	 */
 	public function query(string $sql): ?Dibi\ResultDriver
 	{
-		$res = $this->connection->query($sql);
-		if ($res) {
-			$this->affectedRows = $res->rowCount();
-			return $res->columnCount() ? $this->createResultDriver($res) : null;
+		try {
+			$res = $this->connection->query($sql);
+			if ($res) {
+				$this->affectedRows = $res->rowCount();
+				return $res->columnCount() ? $this->createResultDriver($res) : null;
+			}
+			[$sqlState, $code, $message] = $this->connection->errorInfo();
+		} catch (PDOException $e) {
+			[$sqlState, $code, $message] = $e->errorInfo;
 		}
-
 		$this->affectedRows = null;
 
-		[$sqlState, $code, $message] = $this->connection->errorInfo();
 		$message = "SQLSTATE[$sqlState]: $message";
 		switch ($this->driverName) {
 			case 'mysql':

--- a/src/Dibi/Drivers/PdoResult.php
+++ b/src/Dibi/Drivers/PdoResult.php
@@ -21,11 +21,9 @@ class PdoResult implements Dibi\ResultDriver
 {
 	use Dibi\Strict;
 
-	/** @var \PDOStatement|null */
-	private $resultSet;
+	private ?\PDOStatement $resultSet;
 
-	/** @var string */
-	private $driverName;
+	private string $driverName;
 
 
 	public function __construct(\PDOStatement $resultSet, string $driverName)

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -227,7 +227,7 @@ class PostgreDriver implements Dibi\Driver
 	 * Returns the connection resource.
 	 * @return resource|null
 	 */
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return is_resource($this->connection) || $this->connection instanceof PgSql\Connection
 			? $this->connection

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -33,8 +33,7 @@ class PostgreDriver implements Dibi\Driver
 	/** @var resource|PgSql\Connection */
 	private $connection;
 
-	/** @var int|null  Affected rows */
-	private $affectedRows;
+	private ?int $affectedRows;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/PostgreDriver.php
+++ b/src/Dibi/Drivers/PostgreDriver.php
@@ -139,7 +139,7 @@ class PostgreDriver implements Dibi\Driver
 			$message = substr($message, strlen($m[0]));
 		}
 
-		if ($code === '0A000' && strpos($message, 'truncate') !== false) {
+		if ($code === '0A000' && str_contains($message, 'truncate')) {
 			return new Dibi\ForeignKeyConstraintViolationException($message, $code, $sql);
 
 		} elseif ($code === '23502') {

--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -19,11 +19,9 @@ class PostgreReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
-	/** @var string */
-	private $version;
+	private string $version;
 
 
 	public function __construct(Dibi\Driver $driver, string $version)

--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -126,7 +126,7 @@ class PostgreReflector implements Dibi\Reflector
 				'size' => $size > 0 ? $size : null,
 				'nullable' => $row['is_nullable'] === 'YES' || $row['is_nullable'] === 't' || $row['is_nullable'] === true,
 				'default' => $row['column_default'],
-				'autoincrement' => (int) $row['ordinal_position'] === $primary && substr($row['column_default'] ?? '', 0, 7) === 'nextval',
+				'autoincrement' => (int) $row['ordinal_position'] === $primary && str_starts_with($row['column_default'] ?? '', 'nextval'),
 				'vendor' => $row,
 			];
 		}

--- a/src/Dibi/Drivers/PostgreResult.php
+++ b/src/Dibi/Drivers/PostgreResult.php
@@ -24,8 +24,7 @@ class PostgreResult implements Dibi\ResultDriver
 	/** @var resource|PgSql\Result */
 	private $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
 
 	/**

--- a/src/Dibi/Drivers/PostgreResult.php
+++ b/src/Dibi/Drivers/PostgreResult.php
@@ -111,7 +111,7 @@ class PostgreResult implements Dibi\ResultDriver
 	 * Returns the result set resource.
 	 * @return resource|PgSql\Result|null
 	 */
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		$this->autoFree = false;
 		return is_resource($this->resultSet) || $this->resultSet instanceof PgSql\Result

--- a/src/Dibi/Drivers/SqliteDriver.php
+++ b/src/Dibi/Drivers/SqliteDriver.php
@@ -27,14 +27,11 @@ class SqliteDriver implements Dibi\Driver
 {
 	use Dibi\Strict;
 
-	/** @var SQLite3 */
-	private $connection;
+	private SQLite3 $connection;
 
-	/** @var string  Date format */
-	private $fmtDate;
+	private string $fmtDate;
 
-	/** @var string  Datetime format */
-	private $fmtDateTime;
+	private string $fmtDateTime;
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/SqliteDriver.php
+++ b/src/Dibi/Drivers/SqliteDriver.php
@@ -99,19 +99,19 @@ class SqliteDriver implements Dibi\Driver
 		if ($code !== 19) {
 			return new Dibi\DriverException($message, $code, $sql);
 
-		} elseif (strpos($message, 'must be unique') !== false
-			|| strpos($message, 'is not unique') !== false
-			|| strpos($message, 'UNIQUE constraint failed') !== false
+		} elseif (str_contains($message, 'must be unique')
+			|| str_contains($message, 'is not unique')
+			|| str_contains($message, 'UNIQUE constraint failed')
 		) {
 			return new Dibi\UniqueConstraintViolationException($message, $code, $sql);
 
-		} elseif (strpos($message, 'may not be null') !== false
-			|| strpos($message, 'NOT NULL constraint failed') !== false
+		} elseif (str_contains($message, 'may not be null')
+			|| str_contains($message, 'NOT NULL constraint failed')
 		) {
 			return new Dibi\NotNullConstraintViolationException($message, $code, $sql);
 
-		} elseif (strpos($message, 'foreign key constraint failed') !== false
-			|| strpos($message, 'FOREIGN KEY constraint failed') !== false
+		} elseif (str_contains($message, 'foreign key constraint failed')
+			|| str_contains($message, 'FOREIGN KEY constraint failed')
 		) {
 			return new Dibi\ForeignKeyConstraintViolationException($message, $code, $sql);
 

--- a/src/Dibi/Drivers/SqliteDriver.php
+++ b/src/Dibi/Drivers/SqliteDriver.php
@@ -291,7 +291,7 @@ class SqliteDriver implements Dibi\Driver
 		string $name,
 		callable $rowCallback,
 		callable $agrCallback,
-		int $numArgs = -1
+		int $numArgs = -1,
 	): void {
 		$this->connection->createAggregate($name, $rowCallback, $agrCallback, $numArgs);
 	}

--- a/src/Dibi/Drivers/SqliteReflector.php
+++ b/src/Dibi/Drivers/SqliteReflector.php
@@ -19,8 +19,7 @@ class SqliteReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/SqliteResult.php
+++ b/src/Dibi/Drivers/SqliteResult.php
@@ -20,11 +20,9 @@ class SqliteResult implements Dibi\ResultDriver
 {
 	use Dibi\Strict;
 
-	/** @var \SQLite3Result */
-	private $resultSet;
+	private \SQLite3Result $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
 
 	public function __construct(\SQLite3Result $resultSet)

--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -60,7 +60,7 @@ class SqlsrvDriver implements Dibi\Driver
 			$options = $config['options'];
 
 			// Default values
-			$options['CharacterSet'] = $options['CharacterSet'] ?? 'UTF-8';
+			$options['CharacterSet'] ??= 'UTF-8';
 			$options['PWD'] = (string) $options['PWD'];
 			$options['UID'] = (string) $options['UID'];
 			$options['Database'] = (string) $options['Database'];

--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -168,7 +168,7 @@ class SqlsrvDriver implements Dibi\Driver
 	 * Returns the connection resource.
 	 * @return resource|null
 	 */
-	public function getResource()
+	public function getResource(): mixed
 	{
 		return is_resource($this->connection) ? $this->connection : null;
 	}

--- a/src/Dibi/Drivers/SqlsrvDriver.php
+++ b/src/Dibi/Drivers/SqlsrvDriver.php
@@ -32,11 +32,9 @@ class SqlsrvDriver implements Dibi\Driver
 	/** @var resource */
 	private $connection;
 
-	/** @var int|null  Affected rows */
-	private $affectedRows;
+	private ?int $affectedRows;
 
-	/** @var string */
-	private $version = '';
+	private string $version = '';
 
 
 	/** @throws Dibi\NotSupportedException */

--- a/src/Dibi/Drivers/SqlsrvReflector.php
+++ b/src/Dibi/Drivers/SqlsrvReflector.php
@@ -19,8 +19,7 @@ class SqlsrvReflector implements Dibi\Reflector
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Driver */
-	private $driver;
+	private Dibi\Driver $driver;
 
 
 	public function __construct(Dibi\Driver $driver)

--- a/src/Dibi/Drivers/SqlsrvResult.php
+++ b/src/Dibi/Drivers/SqlsrvResult.php
@@ -104,7 +104,7 @@ class SqlsrvResult implements Dibi\ResultDriver
 	 * Returns the result set resource.
 	 * @return resource|null
 	 */
-	public function getResultResource()
+	public function getResultResource(): mixed
 	{
 		$this->autoFree = false;
 		return is_resource($this->resultSet) ? $this->resultSet : null;

--- a/src/Dibi/Drivers/SqlsrvResult.php
+++ b/src/Dibi/Drivers/SqlsrvResult.php
@@ -22,8 +22,7 @@ class SqlsrvResult implements Dibi\ResultDriver
 	/** @var resource */
 	private $resultSet;
 
-	/** @var bool */
-	private $autoFree = true;
+	private bool $autoFree = true;
 
 
 	/**

--- a/src/Dibi/Event.php
+++ b/src/Dibi/Event.php
@@ -75,10 +75,7 @@ class Event
 	}
 
 
-	/**
-	 * @param  Result|DriverException|null  $result
-	 */
-	public function done($result = null): self
+	public function done(Result|DriverException|null $result = null): static
 	{
 		$this->result = $result;
 		try {

--- a/src/Dibi/Event.php
+++ b/src/Dibi/Event.php
@@ -63,7 +63,7 @@ class Event
 
 		$dibiDir = dirname((new \ReflectionClass('dibi'))->getFileName()) . DIRECTORY_SEPARATOR;
 		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $row) {
-			if (isset($row['file']) && is_file($row['file']) && strpos($row['file'], $dibiDir) !== 0) {
+			if (isset($row['file']) && is_file($row['file']) && !str_starts_with($row['file'], $dibiDir)) {
 				$this->source = [$row['file'], (int) $row['line']];
 				break;
 			}

--- a/src/Dibi/Event.php
+++ b/src/Dibi/Event.php
@@ -31,26 +31,19 @@ class Event
 		TRANSACTION = 448, // BEGIN | COMMIT | ROLLBACK
 		ALL = 1023;
 
-	/** @var Connection */
-	public $connection;
+	public Connection $connection;
 
-	/** @var int */
-	public $type;
+	public int $type;
 
-	/** @var string */
-	public $sql;
+	public string $sql;
 
-	/** @var Result|DriverException|null */
-	public $result;
+	public Result|DriverException|null $result;
 
-	/** @var float */
-	public $time;
+	public float $time;
 
-	/** @var int|null */
-	public $count;
+	public ?int $count = null;
 
-	/** @var array|null */
-	public $source;
+	public ?array $source = null;
 
 
 	public function __construct(Connection $connection, int $type, ?string $sql = null)

--- a/src/Dibi/Expression.php
+++ b/src/Dibi/Expression.php
@@ -17,8 +17,7 @@ class Expression
 {
 	use Strict;
 
-	/** @var array */
-	private $values;
+	private array $values;
 
 
 	public function __construct(...$values)

--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -411,12 +411,7 @@ class Fluent implements IDataSource
 	 */
 	final public function __toString(): string
 	{
-		try {
-			return $this->connection->translate($this->_export());
-		} catch (\Throwable $e) {
-			trigger_error($e->getMessage(), E_USER_ERROR);
-			return '';
-		}
+		return $this->connection->translate($this->_export());
 	}
 
 

--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -120,7 +120,7 @@ class Fluent implements IDataSource
 	/**
 	 * Appends new argument to the clause.
 	 */
-	public function __call(string $clause, array $args): self
+	public function __call(string $clause, array $args): static
 	{
 		$clause = self::$normalizer->$clause;
 
@@ -207,7 +207,7 @@ class Fluent implements IDataSource
 	/**
 	 * Switch to a clause.
 	 */
-	public function clause(string $clause): self
+	public function clause(string $clause): static
 	{
 		$this->cursor = &$this->clauses[self::$normalizer->$clause];
 		if ($this->cursor === null) {
@@ -221,7 +221,7 @@ class Fluent implements IDataSource
 	/**
 	 * Removes a clause.
 	 */
-	public function removeClause(string $clause): self
+	public function removeClause(string $clause): static
 	{
 		$this->clauses[self::$normalizer->$clause] = null;
 		return $this;
@@ -231,7 +231,7 @@ class Fluent implements IDataSource
 	/**
 	 * Change a SQL flag.
 	 */
-	public function setFlag(string $flag, bool $value = true): self
+	public function setFlag(string $flag, bool $value = true): static
 	{
 		$flag = strtoupper($flag);
 		if ($value) {
@@ -271,7 +271,7 @@ class Fluent implements IDataSource
 	/**
 	 * Adds Result setup.
 	 */
-	public function setupResult(string $method): self
+	public function setupResult(string $method): static
 	{
 		$this->setups[] = func_get_args();
 		return $this;
@@ -283,10 +283,10 @@ class Fluent implements IDataSource
 
 	/**
 	 * Generates and executes SQL query.
-	 * @return Result|int|null  result set or number of affected rows
+	 * Returns result set or number of affected rows
 	 * @throws Exception
 	 */
-	public function execute(?string $return = null)
+	public function execute(?string $return = null): Result|int|null
 	{
 		$res = $this->query($this->_export());
 		switch ($return) {
@@ -302,9 +302,8 @@ class Fluent implements IDataSource
 
 	/**
 	 * Generates, executes SQL query and fetches the single row.
-	 * @return Row|array|null
 	 */
-	public function fetch()
+	public function fetch(): Row|array|null
 	{
 		return $this->command === 'SELECT' && !$this->clauses['LIMIT']
 			? $this->query($this->_export(null, ['%lmt', 1]))->fetch()
@@ -314,9 +313,9 @@ class Fluent implements IDataSource
 
 	/**
 	 * Like fetch(), but returns only first field.
-	 * @return mixed  value on success, null if no next record
+	 * Returns value on success, null if no next record
 	 */
-	public function fetchSingle()
+	public function fetchSingle(): mixed
 	{
 		return $this->command === 'SELECT' && !$this->clauses['LIMIT']
 			? $this->query($this->_export(null, ['%lmt', 1]))->fetchSingle()

--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -47,8 +47,7 @@ class Fluent implements IDataSource
 
 	public const REMOVE = false;
 
-	/** @var array */
-	public static $masks = [
+	public static array $masks = [
 		'SELECT' => ['SELECT', 'DISTINCT', 'FROM', 'WHERE', 'GROUP BY',
 			'HAVING', 'ORDER BY', 'LIMIT', 'OFFSET', ],
 		'UPDATE' => ['UPDATE', 'SET', 'WHERE', 'ORDER BY', 'LIMIT'],
@@ -56,8 +55,8 @@ class Fluent implements IDataSource
 		'DELETE' => ['DELETE', 'FROM', 'USING', 'WHERE', 'ORDER BY', 'LIMIT'],
 	];
 
-	/** @var array  default modifiers for arrays */
-	public static $modifiers = [
+	/** default modifiers for arrays */
+	public static array $modifiers = [
 		'SELECT' => '%n',
 		'FROM' => '%n',
 		'IN' => '%in',
@@ -69,8 +68,8 @@ class Fluent implements IDataSource
 		'GROUP BY' => '%by',
 	];
 
-	/** @var array  clauses separators */
-	public static $separators = [
+	/** clauses separators */
+	public static array $separators = [
 		'SELECT' => ',',
 		'FROM' => ',',
 		'WHERE' => 'AND',
@@ -84,41 +83,35 @@ class Fluent implements IDataSource
 		'INTO' => false,
 	];
 
-	/** @var array  clauses */
-	public static $clauseSwitches = [
+	/** clauses */
+	public static array $clauseSwitches = [
 		'JOIN' => 'FROM',
 		'INNER JOIN' => 'FROM',
 		'LEFT JOIN' => 'FROM',
 		'RIGHT JOIN' => 'FROM',
 	];
 
-	/** @var Connection */
-	private $connection;
+	private Connection $connection;
 
-	/** @var array */
-	private $setups = [];
+	private array $setups = [];
 
-	/** @var string|null */
-	private $command;
+	private ?string $command = null;
 
-	/** @var array */
-	private $clauses = [];
+	private array $clauses = [];
 
-	/** @var array */
-	private $flags = [];
+	private array $flags = [];
 
-	/** @var array|null */
 	private $cursor;
 
-	/** @var HashMap  normalized clauses */
-	private static $normalizer;
+	/** normalized clauses */
+	private static HashMap $normalizer;
 
 
 	public function __construct(Connection $connection)
 	{
 		$this->connection = $connection;
 
-		if (self::$normalizer === null) {
+		if (!isset(self::$normalizer)) {
 			self::$normalizer = new HashMap([self::class, '_formatClause']);
 		}
 	}

--- a/src/Dibi/Helpers.php
+++ b/src/Dibi/Helpers.php
@@ -19,9 +19,8 @@ class Helpers
 
 	/**
 	 * Prints out a syntax highlighted version of the SQL command or Result.
-	 * @param  string|Result  $sql
 	 */
-	public static function dump($sql = null, bool $return = false): ?string
+	public static function dump(string|Result|null $sql = null, bool $return = false): ?string
 	{
 		ob_start();
 		if ($sql instanceof Result && PHP_SAPI === 'cli') {
@@ -237,7 +236,7 @@ class Helpers
 
 	/**
 	 * Import SQL dump from file.
-	 * @return int  count of sql commands
+	 * Returns count of sql commands
 	 */
 	public static function loadFromFile(Connection $connection, string $file, ?callable $onProgress = null): int
 	{
@@ -285,14 +284,14 @@ class Helpers
 
 
 	/** @internal */
-	public static function false2Null($val)
+	public static function false2Null(mixed $val): mixed
 	{
 		return $val === false ? null : $val;
 	}
 
 
 	/** @internal */
-	public static function intVal($value): int
+	public static function intVal(mixed $value): int
 	{
 		if (is_int($value)) {
 			return $value;

--- a/src/Dibi/Helpers.php
+++ b/src/Dibi/Helpers.php
@@ -24,7 +24,7 @@ class Helpers
 	{
 		ob_start();
 		if ($sql instanceof Result && PHP_SAPI === 'cli') {
-			$hasColors = (substr((string) getenv('TERM'), 0, 5) === 'xterm');
+			$hasColors = (str_starts_with((string) getenv('TERM'), 'xterm'));
 			$maxLen = 0;
 			foreach ($sql as $i => $row) {
 				if ($i === 0) {
@@ -89,7 +89,7 @@ class Helpers
 			// syntax highlight
 			$highlighter = "#(/\\*.+?\\*/)|(\\*\\*.+?\\*\\*)|(?<=[\\s,(])($keywords1)(?=[\\s,)])|(?<=[\\s,(=])($keywords2)(?=[\\s,)=])#is";
 			if (PHP_SAPI === 'cli') {
-				if (substr((string) getenv('TERM'), 0, 5) === 'xterm') {
+				if (str_starts_with((string) getenv('TERM'), 'xterm')) {
 					$sql = preg_replace_callback($highlighter, function (array $m) {
 						if (!empty($m[1])) { // comment
 							return "\033[1;30m" . $m[1] . "\033[0m";
@@ -257,7 +257,7 @@ class Helpers
 			if (strtoupper(substr($s, 0, 10)) === 'DELIMITER ') {
 				$delimiter = trim(substr($s, 10));
 
-			} elseif (substr($ts = rtrim($s), -strlen($delimiter)) === $delimiter) {
+			} elseif (str_ends_with($ts = rtrim($s), $delimiter)) {
 				$sql .= substr($ts, 0, -strlen($delimiter));
 				$driver->query($sql);
 				$sql = '';

--- a/src/Dibi/Helpers.php
+++ b/src/Dibi/Helpers.php
@@ -14,8 +14,7 @@ class Helpers
 {
 	use Strict;
 
-	/** @var HashMap */
-	private static $types;
+	private static HashMap $types;
 
 
 	/**
@@ -211,7 +210,7 @@ class Helpers
 	/** @internal */
 	public static function getTypeCache(): HashMap
 	{
-		if (self::$types === null) {
+		if (!isset(self::$types)) {
 			self::$types = new HashMap([self::class, 'detectType']);
 		}
 

--- a/src/Dibi/Literal.php
+++ b/src/Dibi/Literal.php
@@ -17,8 +17,7 @@ class Literal
 {
 	use Strict;
 
-	/** @var string */
-	private $value;
+	private string $value;
 
 
 	public function __construct($value)

--- a/src/Dibi/Loggers/FileLogger.php
+++ b/src/Dibi/Loggers/FileLogger.php
@@ -58,7 +58,7 @@ class FileLogger
 			$this->writeToFile(
 				$event,
 				"ERROR: $message"
-					. "\n-- SQL: " . $event->sql
+					. "\n-- SQL: " . $event->sql,
 			);
 		} else {
 			$this->writeToFile(
@@ -66,7 +66,7 @@ class FileLogger
 				'OK: ' . $event->sql
 					. ($event->count ? ";\n-- rows: " . $event->count : '')
 					. "\n-- takes: " . sprintf('%0.3f ms', $event->time * 1000)
-					. "\n-- source: " . implode(':', $event->source)
+					. "\n-- source: " . implode(':', $event->source),
 			);
 		}
 	}
@@ -76,7 +76,7 @@ class FileLogger
 	{
 		$driver = $event->connection->getConfig('driver');
 		$message .=
-			"\n-- driver: " . (is_object($driver) ? get_class($driver) : $driver) . '/' . $event->connection->getConfig('name')
+			"\n-- driver: " . (is_object($driver) ? $driver::class : $driver) . '/' . $event->connection->getConfig('name')
 			. "\n-- " . date('Y-m-d H:i:s')
 			. "\n\n";
 		file_put_contents($this->file, $message, FILE_APPEND | LOCK_EX);

--- a/src/Dibi/Loggers/FileLogger.php
+++ b/src/Dibi/Loggers/FileLogger.php
@@ -19,14 +19,12 @@ class FileLogger
 {
 	use Dibi\Strict;
 
-	/** @var string  Name of the file where SQL errors should be logged */
-	public $file;
+	/** Name of the file where SQL errors should be logged */
+	public string $file;
 
-	/** @var int */
-	public $filter;
+	public int $filter;
 
-	/** @var bool */
-	private $errorsOnly;
+	private bool $errorsOnly;
 
 
 	public function __construct(string $file, ?int $filter = null, bool $errorsOnly = false)

--- a/src/Dibi/Reflection/Column.php
+++ b/src/Dibi/Reflection/Column.php
@@ -109,15 +109,13 @@ class Column
 	}
 
 
-	/** @return mixed */
-	public function getDefault()
+	public function getDefault(): mixed
 	{
 		return $this->info['default'] ?? null;
 	}
 
 
-	/** @return mixed */
-	public function getVendorInfo(string $key)
+	public function getVendorInfo(string $key): mixed
 	{
 		return $this->info['vendor'][$key] ?? null;
 	}

--- a/src/Dibi/Reflection/Column.php
+++ b/src/Dibi/Reflection/Column.php
@@ -29,11 +29,11 @@ class Column
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Reflector|null when created by Result */
-	private $reflector;
+	/** when created by Result */
+	private ?Dibi\Reflector $reflector;
 
 	/** @var array (name, nativetype, [table], [fullname], [size], [nullable], [default], [autoincrement], [vendor]) */
-	private $info;
+	private array $info;
 
 
 	public function __construct(?Dibi\Reflector $reflector, array $info)

--- a/src/Dibi/Reflection/Database.php
+++ b/src/Dibi/Reflection/Database.php
@@ -23,14 +23,12 @@ class Database
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Reflector */
-	private $reflector;
+	private Dibi\Reflector $reflector;
 
-	/** @var string|null */
-	private $name;
+	private ?string $name;
 
-	/** @var Table[]|null */
-	private $tables;
+	/** @var Table[] */
+	private array $tables;
 
 
 	public function __construct(Dibi\Reflector $reflector, ?string $name = null)
@@ -89,7 +87,7 @@ class Database
 
 	protected function init(): void
 	{
-		if ($this->tables === null) {
+		if (!isset($this->tables)) {
 			$this->tables = [];
 			foreach ($this->reflector->getTables() as $info) {
 				$this->tables[strtolower($info['name'])] = new Table($this->reflector, $info);

--- a/src/Dibi/Reflection/ForeignKey.php
+++ b/src/Dibi/Reflection/ForeignKey.php
@@ -22,11 +22,10 @@ class ForeignKey
 {
 	use Dibi\Strict;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
 	/** @var array of [local, foreign, onDelete, onUpdate] */
-	private $references;
+	private array $references;
 
 
 	public function __construct(string $name, array $references)

--- a/src/Dibi/Reflection/Index.php
+++ b/src/Dibi/Reflection/Index.php
@@ -25,7 +25,7 @@ class Index
 	use Dibi\Strict;
 
 	/** @var array (name, columns, [unique], [primary]) */
-	private $info;
+	private array $info;
 
 
 	public function __construct(array $info)

--- a/src/Dibi/Reflection/Result.php
+++ b/src/Dibi/Reflection/Result.php
@@ -22,14 +22,13 @@ class Result
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\ResultDriver */
-	private $driver;
+	private Dibi\ResultDriver $driver;
 
 	/** @var Column[]|null */
-	private $columns;
+	private ?array $columns;
 
 	/** @var Column[]|null */
-	private $names;
+	private ?array $names;
 
 
 	public function __construct(Dibi\ResultDriver $driver)
@@ -81,7 +80,7 @@ class Result
 
 	protected function initColumns(): void
 	{
-		if ($this->columns === null) {
+		if (!isset($this->columns)) {
 			$this->columns = [];
 			$reflector = $this->driver instanceof Dibi\Reflector
 				? $this->driver

--- a/src/Dibi/Reflection/Table.php
+++ b/src/Dibi/Reflection/Table.php
@@ -27,26 +27,22 @@ class Table
 {
 	use Dibi\Strict;
 
-	/** @var Dibi\Reflector */
-	private $reflector;
+	private Dibi\Reflector $reflector;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
-	/** @var bool */
-	private $view;
+	private bool $view;
 
-	/** @var Column[]|null */
-	private $columns;
+	/** @var Column[] */
+	private array $columns;
 
-	/** @var ForeignKey[]|null */
-	private $foreignKeys;
+	/** @var ForeignKey[] */
+	private array $foreignKeys;
 
-	/** @var Index[]|null */
-	private $indexes;
+	/** @var Index[] */
+	private array $indexes;
 
-	/** @var Index|null */
-	private $primaryKey;
+	private ?Index $primaryKey;
 
 
 	public function __construct(Dibi\Reflector $reflector, array $info)
@@ -135,7 +131,7 @@ class Table
 
 	protected function initColumns(): void
 	{
-		if ($this->columns === null) {
+		if (!isset($this->columns)) {
 			$this->columns = [];
 			foreach ($this->reflector->getColumns($this->name) as $info) {
 				$this->columns[strtolower($info['name'])] = new Column($this->reflector, $info);
@@ -146,7 +142,7 @@ class Table
 
 	protected function initIndexes(): void
 	{
-		if ($this->indexes === null) {
+		if (!isset($this->indexes)) {
 			$this->initColumns();
 			$this->indexes = [];
 			foreach ($this->reflector->getIndexes($this->name) as $info) {

--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -234,7 +234,7 @@ class Result implements IDataSource
 	 */
 	final public function fetchAssoc(string $assoc): array
 	{
-		if (strpos($assoc, ',') !== false) {
+		if (str_contains($assoc, ',')) {
 			return $this->oldFetchAssoc($assoc);
 		}
 
@@ -491,7 +491,7 @@ class Result implements IDataSource
 				$row[$key] = ((bool) $value) && $value !== 'f' && $value !== 'F';
 
 			} elseif ($type === Type::DATETIME || $type === Type::DATE || $type === Type::TIME) {
-				if ($value && substr((string) $value, 0, 7) !== '0000-00') { // '', null, false, '0000-00-00', ...
+				if ($value && !str_starts_with((string) $value, '0000-00')) { // '', null, false, '0000-00-00', ...
 					$value = new DateTime($value);
 					$row[$key] = $format ? $value->format($format) : $value;
 				} else {

--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -19,26 +19,23 @@ class Result implements IDataSource
 {
 	use Strict;
 
-	/** @var ResultDriver|null */
-	private $driver;
+	private ?ResultDriver $driver;
 
-	/** @var array  Translate table */
-	private $types = [];
+	/** Translate table */
+	private array $types = [];
 
-	/** @var Reflection\Result|null */
-	private $meta;
+	private ?Reflection\Result $meta;
 
-	/** @var bool  Already fetched? Used for allowance for first seek(0) */
-	private $fetched = false;
+	/** Already fetched? Used for allowance for first seek(0) */
+	private bool $fetched = false;
 
-	/** @var string|null  returned object class */
-	private $rowClass = Row::class;
+	/** returned object class */
+	private ?string $rowClass = Row::class;
 
 	/** @var callable|null  returned object factory */
 	private $rowFactory;
 
-	/** @var array  format */
-	private $formats = [];
+	private array $formats = [];
 
 
 	public function __construct(ResultDriver $driver, bool $normalize = true)
@@ -591,7 +588,7 @@ class Result implements IDataSource
 	 */
 	public function getInfo(): Reflection\Result
 	{
-		if ($this->meta === null) {
+		if (!isset($this->meta)) {
 			$this->meta = new Reflection\Result($this->getResultDriver());
 		}
 

--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -206,7 +206,7 @@ class Result implements IDataSource
 	 */
 	final public function fetchAll(?int $offset = null, ?int $limit = null): array
 	{
-		$limit = $limit ?? -1;
+		$limit ??= -1;
 		$this->seek($offset ?: 0);
 		$row = $this->fetch();
 		if (!$row) {

--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -130,7 +130,7 @@ class Result implements IDataSource
 	/**
 	 * Set fetched object class. This class should extend the Row class.
 	 */
-	public function setRowClass(?string $class): self
+	public function setRowClass(?string $class): static
 	{
 		$this->rowClass = $class;
 		return $this;
@@ -149,7 +149,7 @@ class Result implements IDataSource
 	/**
 	 * Set a factory to create fetched object instances. These should extend the Row class.
 	 */
-	public function setRowFactory(callable $callback): self
+	public function setRowFactory(callable $callback): static
 	{
 		$this->rowFactory = $callback;
 		return $this;
@@ -159,9 +159,8 @@ class Result implements IDataSource
 	/**
 	 * Fetches the row at current position, process optional type conversion.
 	 * and moves the internal cursor to the next position
-	 * @return Row|array|null
 	 */
-	final public function fetch()
+	final public function fetch(): Row|array|null
 	{
 		$row = $this->getResultDriver()->fetch(true);
 		if ($row === null) {
@@ -182,9 +181,9 @@ class Result implements IDataSource
 
 	/**
 	 * Like fetch(), but returns only first field.
-	 * @return mixed value on success, null if no next record
+	 * Returns value on success, null if no next record
 	 */
-	final public function fetchSingle()
+	final public function fetchSingle(): mixed
 	{
 		$row = $this->getResultDriver()->fetch(true);
 		if ($row === null) {
@@ -526,7 +525,7 @@ class Result implements IDataSource
 	 * Define column type.
 	 * @param  string|null  $type  use constant Type::*
 	 */
-	final public function setType(string $column, ?string $type): self
+	final public function setType(string $column, ?string $type): static
 	{
 		$this->types[$column] = $type;
 		return $this;
@@ -554,7 +553,7 @@ class Result implements IDataSource
 	/**
 	 * Sets type format.
 	 */
-	final public function setFormat(string $type, ?string $format): self
+	final public function setFormat(string $type, ?string $format): static
 	{
 		$this->formats[$type] = $format;
 		return $this;
@@ -564,7 +563,7 @@ class Result implements IDataSource
 	/**
 	 * Sets type formats.
 	 */
-	final public function setFormats(array $formats): self
+	final public function setFormats(array $formats): static
 	{
 		$this->formats = $formats;
 		return $this;

--- a/src/Dibi/ResultIterator.php
+++ b/src/Dibi/ResultIterator.php
@@ -41,23 +41,19 @@ class ResultIterator implements \Iterator, \Countable
 	}
 
 
-	#[\ReturnTypeWillChange]
 	/**
 	 * Returns the key of the current element.
-	 * @return mixed
 	 */
-	public function key()
+	public function key(): mixed
 	{
 		return $this->pointer;
 	}
 
 
-	#[\ReturnTypeWillChange]
 	/**
 	 * Returns the current element.
-	 * @return mixed
 	 */
-	public function current()
+	public function current(): mixed
 	{
 		return $this->row;
 	}

--- a/src/Dibi/ResultIterator.php
+++ b/src/Dibi/ResultIterator.php
@@ -17,14 +17,11 @@ class ResultIterator implements \Iterator, \Countable
 {
 	use Strict;
 
-	/** @var Result */
-	private $result;
+	private Result $result;
 
-	/** @var mixed */
-	private $row;
+	private mixed $row;
 
-	/** @var int */
-	private $pointer = 0;
+	private int $pointer = 0;
 
 
 	public function __construct(Result $result)

--- a/src/Dibi/Row.php
+++ b/src/Dibi/Row.php
@@ -36,7 +36,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \Countable
 	{
 		$time = $this[$key];
 		if (!$time instanceof DateTime) {
-			if (!$time || substr((string) $time, 0, 7) === '0000-00') { // '', null, false, '0000-00-00', ...
+			if (!$time || str_starts_with((string) $time, '0000-00')) { // '', null, false, '0000-00-00', ...
 				return null;
 			}
 

--- a/src/Dibi/Row.php
+++ b/src/Dibi/Row.php
@@ -31,9 +31,8 @@ class Row implements \ArrayAccess, \IteratorAggregate, \Countable
 
 	/**
 	 * Converts value to DateTime object.
-	 * @return DateTime|string|null
 	 */
-	public function asDateTime(string $key, ?string $format = null)
+	public function asDateTime(string $key, ?string $format = null): DateTime|string|null
 	{
 		$time = $this[$key];
 		if (!$time instanceof DateTime) {
@@ -82,8 +81,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \Countable
 	}
 
 
-	#[\ReturnTypeWillChange]
-	final public function offsetGet($nm)
+	final public function offsetGet($nm): mixed
 	{
 		return $this->$nm;
 	}

--- a/src/Dibi/Strict.php
+++ b/src/Dibi/Strict.php
@@ -31,7 +31,7 @@ trait Strict
 	{
 		$class = method_exists($this, $name) ? 'parent' : static::class;
 		$items = (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC);
-		$items = array_map(function ($item) { return $item->getName(); }, $items);
+		$items = array_map(fn($item) => $item->getName(), $items);
 		$hint = ($t = Helpers::getSuggestion($items, $name))
 			? ", did you mean $t()?"
 			: '.';
@@ -46,8 +46,8 @@ trait Strict
 	public static function __callStatic(string $name, array $args)
 	{
 		$rc = new ReflectionClass(static::class);
-		$items = array_filter($rc->getMethods(\ReflectionMethod::IS_STATIC), function ($m) { return $m->isPublic(); });
-		$items = array_map(function ($item) { return $item->getName(); }, $items);
+		$items = array_filter($rc->getMethods(\ReflectionMethod::IS_STATIC), fn($m) => $m->isPublic());
+		$items = array_map(fn($item) => $item->getName(), $items);
 		$hint = ($t = Helpers::getSuggestion($items, $name))
 			? ", did you mean $t()?"
 			: '.';
@@ -69,8 +69,8 @@ trait Strict
 		}
 
 		$rc = new ReflectionClass($this);
-		$items = array_filter($rc->getProperties(ReflectionProperty::IS_PUBLIC), function ($p) { return !$p->isStatic(); });
-		$items = array_map(function ($item) { return $item->getName(); }, $items);
+		$items = array_filter($rc->getProperties(ReflectionProperty::IS_PUBLIC), fn($p) => !$p->isStatic());
+		$items = array_map(fn($item) => $item->getName(), $items);
 		$hint = ($t = Helpers::getSuggestion($items, $name))
 			? ", did you mean $$t?"
 			: '.';
@@ -85,8 +85,8 @@ trait Strict
 	public function __set(string $name, $value)
 	{
 		$rc = new ReflectionClass($this);
-		$items = array_filter($rc->getProperties(ReflectionProperty::IS_PUBLIC), function ($p) { return !$p->isStatic(); });
-		$items = array_map(function ($item) { return $item->getName(); }, $items);
+		$items = array_filter($rc->getProperties(ReflectionProperty::IS_PUBLIC), fn($p) => !$p->isStatic());
+		$items = array_map(fn($item) => $item->getName(), $items);
 		$hint = ($t = Helpers::getSuggestion($items, $name))
 			? ", did you mean $$t?"
 			: '.';

--- a/src/Dibi/Strict.php
+++ b/src/Dibi/Strict.php
@@ -20,7 +20,7 @@ use ReflectionProperty;
 trait Strict
 {
 	/** @var array [method => [type => callback]] */
-	private static $extMethods;
+	private static array $extMethods;
 
 
 	/**

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -17,38 +17,28 @@ final class Translator
 {
 	use Strict;
 
-	/** @var Connection */
-	private $connection;
+	private Connection $connection;
 
-	/** @var Driver */
-	private $driver;
+	private Driver $driver;
 
-	/** @var int */
-	private $cursor = 0;
+	private int $cursor = 0;
 
-	/** @var array */
-	private $args;
+	private array $args;
 
 	/** @var string[] */
-	private $errors;
+	private array $errors;
 
-	/** @var bool */
-	private $comment = false;
+	private bool $comment = false;
 
-	/** @var int */
-	private $ifLevel = 0;
+	private int $ifLevel = 0;
 
-	/** @var int */
-	private $ifLevelStart = 0;
+	private int $ifLevelStart = 0;
 
-	/** @var int|null */
-	private $limit;
+	private ?int $limit = null;
 
-	/** @var int|null */
-	private $offset;
+	private ?int $offset = null;
 
-	/** @var HashMap */
-	private $identifiers;
+	private HashMap $identifiers;
 
 
 	public function __construct(Connection $connection)

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -198,7 +198,7 @@ final class Translator
 								$v = $this->formatValue($v, $pair[1]);
 								if ($pair[1] === 'l' || $pair[1] === 'in') {
 									$op = 'IN ';
-								} elseif (strpos($pair[1], 'like') !== false) {
+								} elseif (str_contains($pair[1], 'like')) {
 									$op = 'LIKE ';
 								} elseif ($v === 'NULL') {
 									$op = 'IS ';

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -162,9 +162,8 @@ final class Translator
 
 	/**
 	 * Apply modifier to single value.
-	 * @param  mixed  $value
 	 */
-	public function formatValue($value, ?string $modifier): string
+	public function formatValue(mixed $value, ?string $modifier): string
 	{
 		if ($this->comment) {
 			return '...';

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -470,6 +470,11 @@ final class Translator
 			}
 		}
 
+		// object-to-scalar procession
+		if ($value instanceof \BackedEnum && is_scalar($value->value)) {
+			$value = $value->value;
+		}
+
 		// without modifier procession
 		if (is_string($value)) {
 			return $this->driver->escapeText($value);

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -96,22 +96,21 @@ final class Translator
 						// note: this can change $this->args & $this->cursor & ...
 						. preg_replace_callback(
 							<<<'XX'
-							/
-							(?=[`['":%?])                       ## speed-up
-							(?:
-								`(.+?)`|                        ## 1) `identifier`
-								\[(.+?)\]|                      ## 2) [identifier]
-								(')((?:''|[^'])*)'|             ## 3,4) string
-								(")((?:""|[^"])*)"|             ## 5,6) "string"
-								('|")|                          ## 7) lone quote
-								:(\S*?:)([a-zA-Z0-9._]?)|       ## 8,9) :substitution:
-								%([a-zA-Z~][a-zA-Z0-9~]{0,5})|  ## 10) modifier
-								(\?)                            ## 11) placeholder
-							)/xs
-XX
-,
+								/
+								(?=[`['":%?])                       ## speed-up
+								(?:
+									`(.+?)`|                        ## 1) `identifier`
+									\[(.+?)\]|                      ## 2) [identifier]
+									(')((?:''|[^'])*)'|             ## 3,4) string
+									(")((?:""|[^"])*)"|             ## 5,6) "string"
+									('|")|                          ## 7) lone quote
+									:(\S*?:)([a-zA-Z0-9._]?)|       ## 8,9) :substitution:
+									%([a-zA-Z~][a-zA-Z0-9~]{0,5})|  ## 10) modifier
+									(\?)                            ## 11) placeholder
+								)/xs
+								XX,
 							[$this, 'cb'],
-							substr($arg, $toSkip)
+							substr($arg, $toSkip),
 						);
 					if (preg_last_error()) {
 						throw new PcreException;
@@ -280,7 +279,7 @@ XX
 								$proto = array_keys($v);
 							}
 						} else {
-							return $this->errors[] = '**Unexpected type ' . (is_object($v) ? get_class($v) : gettype($v)) . '**';
+							return $this->errors[] = '**Unexpected type ' . (is_object($v) ? $v::class : gettype($v)) . '**';
 						}
 
 						$pair = explode('%', $k, 2); // split into identifier & modifier
@@ -344,7 +343,7 @@ XX
 				) {
 					// continue
 				} else {
-					$type = is_object($value) ? get_class($value) : gettype($value);
+					$type = is_object($value) ? $value::class : gettype($value);
 					return $this->errors[] = "**Invalid combination of type $type and modifier %$modifier**";
 				}
 			}
@@ -432,20 +431,20 @@ XX
 						$value = substr($value, 0, $toSkip)
 							. preg_replace_callback(
 								<<<'XX'
-								/
-								(?=[`['":])
-								(?:
-									`(.+?)`|
-									\[(.+?)\]|
-									(')((?:''|[^'])*)'|
-									(")((?:""|[^"])*)"|
-									('|")|
-									:(\S*?:)([a-zA-Z0-9._]?)
-								)/sx
-XX
+																	/
+																	(?=[`['":])
+																	(?:
+																		`(.+?)`|
+																		\[(.+?)\]|
+																		(')((?:''|[^'])*)'|
+																		(")((?:""|[^"])*)"|
+																		('|")|
+																		:(\S*?:)([a-zA-Z0-9._]?)
+																	)/sx
+									XX
 ,
 								[$this, 'cb'],
-								substr($value, $toSkip)
+								substr($value, $toSkip),
 							);
 						if (preg_last_error()) {
 							throw new PcreException;
@@ -511,7 +510,7 @@ XX
 			return $this->connection->translate(...$value->getValues());
 
 		} else {
-			$type = is_object($value) ? get_class($value) : gettype($value);
+			$type = is_object($value) ? $value::class : gettype($value);
 			return $this->errors[] = "**Unexpected $type**";
 		}
 	}

--- a/src/Dibi/dibi.php
+++ b/src/Dibi/dibi.php
@@ -52,23 +52,23 @@ class dibi
 		ASC = 'ASC',
 		DESC = 'DESC';
 
-	/** @var string|null  Last SQL command @see dibi::query() */
-	public static $sql;
+	/** Last SQL command @see dibi::query() */
+	public static ?string $sql = null;
 
-	/** @var float|null  Elapsed time for last query */
-	public static $elapsedTime;
+	/** Elapsed time for last query */
+	public static ?float $elapsedTime = null;
 
-	/** @var float  Elapsed time for all queries */
-	public static $totalTime;
+	/** Elapsed time for all queries */
+	public static float $totalTime = 0;
 
-	/** @var int  Number or queries */
-	public static $numOfQueries = 0;
+	/** Number or queries */
+	public static int $numOfQueries = 0;
 
 	/** @var Dibi\Connection[]  Connection registry storage for Dibi\Connection objects */
-	private static $registry = [];
+	private static array $registry = [];
 
-	/** @var Dibi\Connection  Current connection */
-	private static $connection;
+	/** Current connection */
+	private static Dibi\Connection $connection;
 
 
 	/**

--- a/src/Dibi/dibi.php
+++ b/src/Dibi/dibi.php
@@ -165,7 +165,7 @@ class dibi
 	 */
 	public static function stripMicroseconds(DateTimeInterface $dt): DateTimeInterface
 	{
-		$class = get_class($dt);
+		$class = $dt::class;
 		return new $class($dt->format('Y-m-d H:i:s'), $dt->getTimezone());
 	}
 }

--- a/src/Dibi/dibi.php
+++ b/src/Dibi/dibi.php
@@ -88,7 +88,7 @@ class dibi
 	 * @param  array   $config  connection parameters
 	 * @throws Dibi\Exception
 	 */
-	public static function connect($config = [], string $name = '0'): Dibi\Connection
+	public static function connect(array $config = [], string $name = '0'): Dibi\Connection
 	{
 		return self::$connection = self::$registry[$name] = new Dibi\Connection($config, $name);
 	}
@@ -151,10 +151,9 @@ class dibi
 
 	/**
 	 * Prints out a syntax highlighted version of the SQL command or Result.
-	 * @param  string|Dibi\Result  $sql
 	 * @param  bool  $return  return output instead of printing it?
 	 */
-	public static function dump($sql = null, bool $return = false): ?string
+	public static function dump(string|Dibi\Result|null $sql = null, bool $return = false): ?string
 	{
 		return Dibi\Helpers::dump($sql, $return);
 	}

--- a/src/Dibi/dibi.php
+++ b/src/Dibi/dibi.php
@@ -45,7 +45,7 @@ class dibi
 
 	/** version */
 	public const
-		VERSION = '4.2.5';
+		VERSION = '5.0-dev';
 
 	/** sorting order */
 	public const

--- a/src/Dibi/exceptions.php
+++ b/src/Dibi/exceptions.php
@@ -15,8 +15,7 @@ namespace Dibi;
  */
 class Exception extends \Exception
 {
-	/** @var string|null */
-	private $sql;
+	private ?string $sql;
 
 
 	/**
@@ -86,8 +85,7 @@ class NotSupportedException extends Exception
  */
 class ProcedureException extends Exception
 {
-	/** @var string */
-	protected $severity;
+	protected string $severity;
 
 
 	/**

--- a/src/Dibi/exceptions.php
+++ b/src/Dibi/exceptions.php
@@ -18,11 +18,12 @@ class Exception extends \Exception
 	private ?string $sql;
 
 
-	/**
-	 * @param  int|string  $code
-	 */
-	public function __construct(string $message = '', $code = 0, ?string $sql = null, ?\Throwable $previous = null)
-	{
+	public function __construct(
+		string $message = '',
+		int|string $code = 0,
+		?string $sql = null,
+		?\Throwable $previous = null,
+	) {
 		parent::__construct($message, 0, $previous);
 		$this->code = $code;
 		$this->sql = $sql;

--- a/src/Dibi/interfaces.php
+++ b/src/Dibi/interfaces.php
@@ -67,9 +67,8 @@ interface Driver
 
 	/**
 	 * Returns the connection resource.
-	 * @return mixed
 	 */
-	function getResource();
+	function getResource(): mixed;
 
 	/**
 	 * Returns the connection reflector.
@@ -117,7 +116,6 @@ interface ResultDriver
 
 	/**
 	 * Moves cursor position without fetching row.
-	 * @return bool  true on success, false if unable to seek to specified record
 	 * @throws Exception
 	 */
 	function seek(int $row): bool;
@@ -142,9 +140,8 @@ interface ResultDriver
 
 	/**
 	 * Returns the result set resource.
-	 * @return mixed
 	 */
-	function getResultResource();
+	function getResultResource(): mixed;
 
 	/**
 	 * Decodes data from result set.

--- a/tests/dibi/Connection.fetch.phpt
+++ b/tests/dibi/Connection.fetch.phpt
@@ -33,13 +33,13 @@ Assert::equal([
 $res = $conn->query('SELECT * FROM [products] ORDER BY product_id');
 Assert::same(
 	[1 => 'Chair', 'Table', 'Computer'],
-	$res->fetchPairs('product_id', 'title')
+	$res->fetchPairs('product_id', 'title'),
 );
 
 $res = $conn->query('SELECT * FROM [products] ORDER BY product_id');
 Assert::same(
 	[1 => 'Chair', 'Table', 'Computer'],
-	$res->fetchPairs()
+	$res->fetchPairs(),
 );
 
 

--- a/tests/dibi/Connection.substitutions.phpt
+++ b/tests/dibi/Connection.substitutions.phpt
@@ -14,27 +14,27 @@ $conn->getSubstitutes()->blog = 'wp_';
 
 Assert::same(
 	reformat('UPDATE wp_items SET [val]=1'),
-	$conn->translate('UPDATE :blog:items SET [val]=1')
+	$conn->translate('UPDATE :blog:items SET [val]=1'),
 );
 
 Assert::same(
 	reformat('UPDATE [wp_items] SET [val]=1'),
-	$conn->translate('UPDATE [:blog:items] SET [val]=1')
+	$conn->translate('UPDATE [:blog:items] SET [val]=1'),
 );
 
 Assert::same(
 	reformat("UPDATE 'wp_' SET [val]=1"),
-	$conn->translate('UPDATE :blog: SET [val]=1')
+	$conn->translate('UPDATE :blog: SET [val]=1'),
 );
 
 Assert::same(
 	reformat("UPDATE ':blg:' SET [val]=1"),
-	$conn->translate('UPDATE :blg: SET [val]=1')
+	$conn->translate('UPDATE :blg: SET [val]=1'),
 );
 
 Assert::same(
 	reformat("UPDATE table SET [text]=':blog:a'"),
-	$conn->translate("UPDATE table SET [text]=':blog:a'")
+	$conn->translate("UPDATE table SET [text]=':blog:a'"),
 );
 
 
@@ -43,16 +43,14 @@ $conn->getSubstitutes()->{''} = 'my_';
 
 Assert::same(
 	reformat('UPDATE my_table SET [val]=1'),
-	$conn->translate('UPDATE ::table SET [val]=1')
+	$conn->translate('UPDATE ::table SET [val]=1'),
 );
 
 
 // create substitutions using fallback callback
-$conn->getSubstitutes()->setCallback(function ($expr) {
-	return '_' . $expr . '_';
-});
+$conn->getSubstitutes()->setCallback(fn($expr) => '_' . $expr . '_');
 
 Assert::same(
 	reformat('UPDATE _account_user SET [val]=1'),
-	$conn->translate('UPDATE :account:user SET [val]=1')
+	$conn->translate('UPDATE :account:user SET [val]=1'),
 );

--- a/tests/dibi/DataSource.phpt
+++ b/tests/dibi/DataSource.phpt
@@ -17,7 +17,7 @@ Assert::match(
 	reformat('
 SELECT *
 FROM (SELECT * FROM products) t'),
-	(string) $ds
+	(string) $ds,
 );
 
 
@@ -25,7 +25,7 @@ Assert::same(3, $ds->count());
 Assert::same(3, $ds->getTotalCount());
 Assert::same(
 	reformat('SELECT COUNT(*) FROM (SELECT * FROM products) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 
 
@@ -39,7 +39,7 @@ FROM (SELECT * FROM products) t
  WHERE (title like '%a%')
  ORDER BY [title] DESC
  "),
-	(string) $ds
+	(string) $ds,
 );
 
 
@@ -53,7 +53,7 @@ FROM (SELECT * FROM products) t
  WHERE (title like '%a%') AND (product_id = 1)
  ORDER BY [title] DESC, [product_id] ASC
  "),
-	(string) $ds
+	(string) $ds,
 );
 
 
@@ -67,7 +67,7 @@ FROM (SELECT * FROM products) t
  WHERE (title like '%a%') AND (product_id = 1) AND (product_id = 1)
  ORDER BY [product_id] ASC
  "),
-	(string) $ds
+	(string) $ds,
 );
 
 
@@ -95,7 +95,7 @@ FROM (SELECT * FROM products) t
  WHERE (title like '%a%') AND (product_id = 1) AND (product_id = 1)
  ORDER BY [product_id] ASC
 "),
-	dibi::$sql
+	dibi::$sql,
 );
 
 
@@ -108,7 +108,7 @@ FROM (SELECT * FROM products) t
  WHERE (title like '%a%') AND (product_id = 1) AND (product_id = 1)
  ORDER BY [product_id] ASC
 ) t"),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -117,7 +117,7 @@ Assert::match(
 	reformat('
 SELECT *
 FROM (SELECT [title] FROM [products]) t'),
-	(string) $ds
+	(string) $ds,
 );
 
 Assert::equal(new Row([
@@ -129,7 +129,7 @@ Assert::same(1, $conn->dataSource('SELECT * FROM products ORDER BY product_id')-
 
 Assert::same(
 	[1 => 'Chair', 'Table', 'Computer'],
-	$conn->dataSource('SELECT * FROM products ORDER BY product_id')->fetchPairs()
+	$conn->dataSource('SELECT * FROM products ORDER BY product_id')->fetchPairs(),
 );
 
 Assert::equal([
@@ -154,7 +154,7 @@ Assert::match(
 	reformat('
 SELECT *
 FROM [products]'),
-	(string) $ds
+	(string) $ds,
 );
 
 Assert::same(3, $ds->count());

--- a/tests/dibi/DateTime.phpt
+++ b/tests/dibi/DateTime.phpt
@@ -10,10 +10,10 @@ require __DIR__ . '/bootstrap.php';
 
 date_default_timezone_set('Europe/Prague');
 
-Assert::same('1978-01-23 11:40:00.000000', (string) new DateTime(254400000));
-Assert::same('1978-01-23 11:40:00.000000', (string) (new DateTime)->setTimestamp(254400000));
-Assert::same(254400000, (new DateTime(254400000))->getTimestamp());
+Assert::same('1978-01-23 11:40:00.000000', (string) new DateTime(254_400_000));
+Assert::same('1978-01-23 11:40:00.000000', (string) (new DateTime)->setTimestamp(254_400_000));
+Assert::same(254_400_000, (new DateTime(254_400_000))->getTimestamp());
 
-Assert::same(is_int(2544000000) ? 2544000000 : '2544000000', (new DateTime(2544000000))->getTimestamp()); // 64 bit
+Assert::same(is_int(2_544_000_000) ? 2_544_000_000 : '2544000000', (new DateTime(2_544_000_000))->getTimestamp()); // 64 bit
 
 Assert::same('1978-05-05 00:00:00.000000', (string) new DateTime('1978-05-05'));

--- a/tests/dibi/Fluent.delete.phpt
+++ b/tests/dibi/Fluent.delete.phpt
@@ -15,33 +15,33 @@ $fluent = $conn->delete('table')->as('bAlias')
 
 Assert::same(
 	reformat('DELETE IGNORE FROM [table] AS [bAlias]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->removeClause('from')->from('anotherTable');
 
 Assert::same(
 	reformat('DELETE IGNORE FROM [anotherTable]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->using('thirdTable');
 
 Assert::same(
 	reformat('DELETE IGNORE FROM [anotherTable] USING [thirdTable]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->setFlag('IGNORE', false);
 
 Assert::same(
 	reformat('DELETE FROM [anotherTable] USING [thirdTable]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->limit(10);
 
 Assert::same(
 	reformat('DELETE FROM [anotherTable] USING [thirdTable] LIMIT 10'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/Fluent.fetch.limit.mssql.phpt
+++ b/tests/dibi/Fluent.fetch.limit.mssql.phpt
@@ -58,28 +58,28 @@ $fluent = $conn->select('*')
 
 Assert::same(
 	reformat('SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
 $fluent->fetch();
 Assert::same(
 	'SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t',
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchAll(0, 3);
 Assert::same(
 	reformat('SELECT TOP (3) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -87,16 +87,16 @@ $fluent->limit(0);
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT TOP (0) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT TOP (0) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT TOP (0) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -105,14 +105,14 @@ $fluent->removeClause('offset');
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT TOP (1) * FROM (SELECT * FROM [customers] ORDER BY [customer_id]) t'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id]'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/Fluent.fetch.limit.phpt
+++ b/tests/dibi/Fluent.fetch.limit.phpt
@@ -23,28 +23,28 @@ $fluent = $conn->select('*')
 
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchAll(2, 3);
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 3 OFFSET 2'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -52,16 +52,16 @@ $fluent->limit(0);
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 0 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 0 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 0 OFFSET 3'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -69,16 +69,16 @@ $fluent->removeClause('limit');
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1 OFFSET 3'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 18446744073709551615 OFFSET 3'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -86,14 +86,14 @@ $fluent->removeClause('offset');
 $fluent->fetch();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1'),
-	dibi::$sql
+	dibi::$sql,
 );
 $fluent->fetchSingle();
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id] LIMIT 1'),
-	dibi::$sql
+	dibi::$sql,
 );
 Assert::same(
 	reformat('SELECT * FROM [customers] ORDER BY [customer_id]'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/Fluent.insert.phpt
+++ b/tests/dibi/Fluent.insert.phpt
@@ -21,40 +21,40 @@ $fluent = $conn->insert('table', $arr)
 
 Assert::same(
 	reformat('INSERT IGNORE DELAYED INTO [table] ([title], [price], [brand]) VALUES (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->setFlag('IGNORE', false);
 
 Assert::same(
 	reformat('INSERT DELAYED INTO [table] ([title], [price], [brand]) VALUES (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->setFlag('HIGH_priority');
 
 Assert::same(
 	reformat('INSERT DELAYED HIGH_PRIORITY INTO [table] ([title], [price], [brand]) VALUES (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->into('anotherTable');
 
 Assert::same(
 	reformat('INSERT DELAYED HIGH_PRIORITY INTO [anotherTable] VALUES (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->values('%l', $arr);
 
 Assert::same(
 	reformat('INSERT DELAYED HIGH_PRIORITY INTO [anotherTable] VALUES (\'Super Product\', 12, NULL) , (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->values($arr);
 
 Assert::same(
 	reformat('INSERT DELAYED HIGH_PRIORITY INTO [anotherTable] VALUES (\'Super Product\', 12, NULL) , (\'Super Product\', 12, NULL) , (\'Super Product\', 12, NULL)'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/Fluent.select.phpt
+++ b/tests/dibi/Fluent.select.phpt
@@ -147,9 +147,9 @@ if ($config['system'] === 'mysql') {
 		->limit(' 1; DROP TABLE users')
 		->offset(' 1; DROP TABLE users');
 
-	Assert::error(function () use ($fluent) {
+	Assert::exception(function () use ($fluent) {
 		(string) $fluent;
-	}, E_USER_ERROR, "Expected number, ' 1; DROP TABLE users' given.");
+	}, Dibi\Exception::class, "Expected number, ' 1; DROP TABLE users' given.");
 }
 
 

--- a/tests/dibi/Fluent.select.phpt
+++ b/tests/dibi/Fluent.select.phpt
@@ -25,7 +25,7 @@ $fluent = $conn->select('*')
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->from('table')->as('table.Alias')
@@ -34,21 +34,21 @@ $fluent->from('table')->as('table.Alias')
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [table] AS [table.Alias] INNER JOIN [table1] ON table.col = table1.col INNER JOIN [table2] ON table.col = table2.col'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->from('anotherTable');
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [table] AS [table.Alias] INNER JOIN [table1] ON table.col = table1.col INNER JOIN [table2] ON table.col = table2.col , [anotherTable]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->removeClause('from')->from('anotherTable');
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [anotherTable]'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->as('anotherAlias')
@@ -58,7 +58,7 @@ $fluent->as('anotherAlias')
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [anotherTable] AS [anotherAlias] INNER JOIN [table3] ON table.col = table3.col'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->where('col > %i', $max)
@@ -71,14 +71,14 @@ $fluent->where('col > %i', $max)
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [anotherTable] AS [anotherAlias] INNER JOIN [table3] ON table.col = table3.col WHERE col > 10 OR col < 5 AND active = 1 AND [col] IN (1, 2, 3) ORDER BY [val] ASC , [val2] DESC , [val3] DESC'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->orderBy(Dibi\Fluent::REMOVE);
 
 Assert::same(
 	reformat('SELECT * , [a] , [b] AS [bAlias] , [c], [d], [e] , [d] FROM [anotherTable] AS [anotherAlias] INNER JOIN [table3] ON table.col = table3.col WHERE col > 10 OR col < 5 AND active = 1 AND [col] IN (1, 2, 3)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -86,7 +86,7 @@ $fluent = $conn->select('*')
 	->select(
 		$conn->select('count(*)')
 		->from('precteni')->as('P')
-		->where('P.id_clanku', '=', 'C.id_clanku')
+		->where('P.id_clanku', '=', 'C.id_clanku'),
 	)
 	->from('clanky')->as('C')
 	->where('id_clanku=%i', 123)
@@ -99,7 +99,7 @@ Assert::same(
 		'sqlsrv' => 'SELECT * , (SELECT count(*) FROM [precteni] AS [P] WHERE P.id_clanku = C.id_clanku) FROM [clanky] AS [C] WHERE id_clanku=123 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY',
 		'SELECT * , (SELECT count(*) FROM [precteni] AS [P] WHERE P.id_clanku = C.id_clanku) FROM [clanky] AS [C] WHERE id_clanku=123 LIMIT 1',
 	]),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -112,7 +112,7 @@ $fluent = $conn->select('*')
 
 Assert::same(
 	reformat('SELECT * , [x] AS [xAlias] FROM [products] INNER JOIN [orders] USING (product_id) INNER JOIN [customers] USING ([customer_id]) INNER JOIN [items] USING ([customer_id], [order_id])'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -124,7 +124,7 @@ $fluent = $conn->command()->select()
 
 Assert::same(
 	reformat('SELECT * FROM [products] INNER JOIN [orders] USING (product_id)'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -138,7 +138,7 @@ Assert::same(
 		'sqlsrv' => "SELECT * FROM [me] AS [t] WHERE col > 10 AND ([x] = N'a') AND (b) AND (c)",
 		"SELECT * FROM [me] AS [t] WHERE col > 10 AND ([x] = 'a') AND (b) AND (c)",
 	]),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -158,5 +158,5 @@ $fluent = $conn->select('*')->from('abc')
 
 Assert::same(
 	reformat('SELECT * FROM [abc] WHERE x IN ((SELECT [id] FROM [xyz]))'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/Fluent.update.phpt
+++ b/tests/dibi/Fluent.update.phpt
@@ -21,14 +21,14 @@ $fluent = $conn->update('table', $arr)
 
 Assert::same(
 	reformat('UPDATE IGNORE DELAYED [table] SET [title]=\'Super Product\', [price]=12, [brand]=NULL'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 $fluent->set(['another' => 123]);
 
 Assert::same(
 	reformat('UPDATE IGNORE DELAYED [table] SET [title]=\'Super Product\', [price]=12, [brand]=NULL , [another]=123'),
-	(string) $fluent
+	(string) $fluent,
 );
 
 
@@ -40,5 +40,5 @@ $arr = [
 $fluent = $conn->update(['table1', 'table2'], $arr);
 Assert::same(
 	reformat('UPDATE [table1], [table2] SET [table1].[title]=\'Super Product\', [table2].[price]=12, [table2].[brand]=NULL'),
-	(string) $fluent
+	(string) $fluent,
 );

--- a/tests/dibi/HashMap.phpt
+++ b/tests/dibi/HashMap.phpt
@@ -6,9 +6,7 @@ use Tester\Assert;
 
 require __DIR__ . '/bootstrap.php';
 
-$hash = new Dibi\HashMap(function ($v) {
-	return "b-$v-e";
-});
+$hash = new Dibi\HashMap(fn($v) => "b-$v-e");
 
 Assert::same('b-X-e', $hash->{'X'});
 Assert::same('b--e', $hash->{''});

--- a/tests/dibi/PdoDriver.providedConnection.phpt
+++ b/tests/dibi/PdoDriver.providedConnection.phpt
@@ -18,16 +18,14 @@ function buildPdoDriver(?int $errorMode)
 }
 
 
-// PDO error mode: exception
-Assert::exception(function () {
-	buildPdoDriver(PDO::ERRMODE_EXCEPTION);
-}, Dibi\DriverException::class, 'PDO connection in exception or warning error mode is not supported.');
+// PDO error mode: exception is accepted
+buildPdoDriver(PDO::ERRMODE_EXCEPTION);
 
 
 // PDO error mode: warning
 Assert::exception(function () {
 	buildPdoDriver(PDO::ERRMODE_WARNING);
-}, Dibi\DriverException::class, 'PDO connection in exception or warning error mode is not supported.');
+}, Dibi\DriverException::class, 'PDO connection in warning error mode is not supported.');
 
 
 test('PDO error mode: explicitly set silent', function () {

--- a/tests/dibi/Result.meta.phpt
+++ b/tests/dibi/Result.meta.phpt
@@ -28,14 +28,14 @@ Assert::same(4, $res->getColumnCount());
 
 Assert::same(
 	['product_id', 'order_id', 'name', 'xXx'],
-	$info->getColumnNames()
+	$info->getColumnNames(),
 );
 
 
 if (!in_array($config['driver'], ['sqlite', 'sqlite3', 'pdo', 'sqlsrv'], true)) {
 	Assert::same(
 		['products.product_id', 'orders.order_id', 'customers.name', 'xXx'],
-		$info->getColumnNames(true)
+		$info->getColumnNames(true),
 	);
 }
 

--- a/tests/dibi/Sqlsrv.insert.phpt
+++ b/tests/dibi/Sqlsrv.insert.phpt
@@ -25,7 +25,7 @@ $conn->query(
 	'CREATE TRIGGER %n ON %n AFTER INSERT AS INSERT INTO %n DEFAULT VALUES',
 	'UpdAAB',
 	'aab',
-	'aaa'
+	'aaa',
 );
 
 $conn->query('INSERT INTO %n DEFAULT VALUES', 'aab');

--- a/tests/dibi/Sqlsrv.limits.phpt
+++ b/tests/dibi/Sqlsrv.limits.phpt
@@ -21,19 +21,19 @@ $tests = function ($conn) {
 		// Limit and offset
 		Assert::same(
 			'SELECT 1 OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY',
-			$conn->translate('SELECT 1 %ofs %lmt', 10, 10)
+			$conn->translate('SELECT 1 %ofs %lmt', 10, 10),
 		);
 
 		// Limit only
 		Assert::same(
 			'SELECT 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY',
-			$conn->translate('SELECT 1 %lmt', 10)
+			$conn->translate('SELECT 1 %lmt', 10),
 		);
 
 		// Offset only
 		Assert::same(
 			'SELECT 1 OFFSET 10 ROWS',
-			$conn->translate('SELECT 1 %ofs', 10)
+			$conn->translate('SELECT 1 %ofs', 10),
 		);
 
 		// Offset invalid
@@ -42,7 +42,7 @@ $tests = function ($conn) {
 				$conn->translate('SELECT 1 %ofs', -10);
 			},
 			Dibi\NotSupportedException::class,
-			'Negative offset or limit.'
+			'Negative offset or limit.',
 		);
 
 		// Limit invalid
@@ -51,7 +51,7 @@ $tests = function ($conn) {
 				$conn->translate('SELECT 1 %lmt', -10);
 			},
 			Dibi\NotSupportedException::class,
-			'Negative offset or limit.'
+			'Negative offset or limit.',
 		);
 
 		// Limit invalid, offset valid
@@ -60,7 +60,7 @@ $tests = function ($conn) {
 				$conn->translate('SELECT 1 %ofs %lmt', 10, -10);
 			},
 			Dibi\NotSupportedException::class,
-			'Negative offset or limit.'
+			'Negative offset or limit.',
 		);
 
 		// Limit valid, offset invalid
@@ -69,22 +69,22 @@ $tests = function ($conn) {
 				$conn->translate('SELECT 1 %ofs %lmt', -10, 10);
 			},
 			Dibi\NotSupportedException::class,
-			'Negative offset or limit.'
+			'Negative offset or limit.',
 		);
 	} else {
 		Assert::same(
 			'SELECT TOP (1) * FROM (SELECT 1) t',
-			$conn->translate('SELECT 1 %lmt', 1)
+			$conn->translate('SELECT 1 %lmt', 1),
 		);
 
 		Assert::same(
 			'SELECT 1',
-			$conn->translate('SELECT 1 %lmt', -10)
+			$conn->translate('SELECT 1 %lmt', -10),
 		);
 
 		Assert::exception(
 			$conn->translate('SELECT 1 %ofs %lmt', 10, 10),
-			Dibi\NotSupportedException::class
+			Dibi\NotSupportedException::class,
 		);
 	}
 };

--- a/tests/dibi/Translator.conditions.phpt
+++ b/tests/dibi/Translator.conditions.phpt
@@ -27,8 +27,8 @@ FROM [customers]
 		isset($name),
 		'WHERE [name] LIKE %s',
 		'xxx',
-		'%end'
-	)
+		'%end',
+	),
 );
 
 
@@ -42,8 +42,8 @@ FROM  [customers] /* ... */'),
 SELECT *
 FROM %if',
 		true,
-		'[customers] %else [products]'
-	)
+		'[customers] %else [products]',
+	),
 );
 
 
@@ -62,7 +62,7 @@ FROM [people]
 WHERE [id] > 0
 	%if', false, 'AND [foo]=%i', 1, '
 	%else %if', true, 'AND [bar]=%i', 1, '
-')
+'),
 );
 
 
@@ -97,8 +97,8 @@ WHERE
 		%if',
 		false,
 		'AND [admin]=1 %end
-	%else 1 LIMIT 10 %end'
-	)
+	%else 1 LIMIT 10 %end',
+	),
 );
 
 
@@ -113,6 +113,6 @@ Assert::same(
 		3,
 		'%ofs',
 		5,
-		'%end'
-	)
+		'%end',
+	),
 );

--- a/tests/dibi/Translator.enums.phpt
+++ b/tests/dibi/Translator.enums.phpt
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @phpVersion 8.1
+ * @dataProvider ../databases.ini
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+$conn = new Dibi\Connection($config);
+$translator = new Dibi\Translator($conn);
+
+
+enum EnumInt: int
+{
+	case One = 1;
+}
+
+enum EnumString: string
+{
+	case One = 'one';
+}
+
+enum PureEnum
+{
+	case One;
+}
+
+
+Assert::equal('1', $translator->formatValue(EnumInt::One, null));
+
+Assert::equal(match ($config['driver']) {
+	'sqlsrv' => "N'one'",
+	default => "'one'",
+}, $translator->formatValue(EnumString::One, null));
+
+Assert::equal('**Unexpected PureEnum**', $translator->formatValue(PureEnum::One, null));

--- a/tests/dibi/Translator.identifiers.phpt
+++ b/tests/dibi/Translator.identifiers.phpt
@@ -15,35 +15,35 @@ $conn = new Dibi\Connection($config);
 
 Assert::same(
 	reformat('SELECT * FROM where WHERE select < 2'),
-	$conn->translate('SELECT * FROM where WHERE select < 2')
+	$conn->translate('SELECT * FROM where WHERE select < 2'),
 );
 
 
 Assert::same(
 	reformat('SELECT * FROM [where] WHERE where.select < 2'),
-	$conn->translate('SELECT * FROM [where] WHERE where.select < 2')
+	$conn->translate('SELECT * FROM [where] WHERE where.select < 2'),
 );
 
 
 Assert::same(
 	reformat('SELECT * FROM [where] WHERE [where].[select] < 2'),
-	$conn->translate('SELECT * FROM [where] WHERE [where.select] < 2')
+	$conn->translate('SELECT * FROM [where] WHERE [where.select] < 2'),
 );
 
 
 Assert::same(
 	reformat('SELECT * FROM [where] as [temp] WHERE [temp].[select] < 2'),
-	$conn->translate('SELECT * FROM [where] as [temp] WHERE [temp.select] < 2')
+	$conn->translate('SELECT * FROM [where] as [temp] WHERE [temp.select] < 2'),
 );
 
 
 Assert::same(
 	reformat('SELECT * FROM [where] WHERE [quot\'n\' space] > 2'),
-	$conn->translate("SELECT * FROM [where] WHERE [quot'n' space] > 2")
+	$conn->translate("SELECT * FROM [where] WHERE [quot'n' space] > 2"),
 );
 
 
 Assert::same(
 	reformat('SELECT * FROM [where] WHERE [where].[quot\'n\' space] > 2'),
-	$conn->translate("SELECT * FROM [where] WHERE [where.quot'n' space] > 2")
+	$conn->translate("SELECT * FROM [where] WHERE [where.quot'n' space] > 2"),
 );

--- a/tests/dibi/Translator.phpt
+++ b/tests/dibi/Translator.phpt
@@ -23,7 +23,7 @@ Assert::same(
 	$conn->translate('REPLACE INTO [products]', [
 		'title' => 'Drticka',
 		'price' => 318,
-	])
+	]),
 );
 
 
@@ -38,7 +38,7 @@ Assert::same(
 		'sqlsrv' => "INSERT INTO [products] ([title], [price], [brand]) VALUES (N'Super Product', 12, NULL) , (N'Super Product', 12, NULL) , (N'Super Product', 12, NULL)",
 		"INSERT INTO [products] ([title], [price], [brand]) VALUES ('Super Product', 12, NULL) , ('Super Product', 12, NULL) , ('Super Product', 12, NULL)",
 	]),
-	$conn->translate('INSERT INTO [products]', $array, $array, $array)
+	$conn->translate('INSERT INTO [products]', $array, $array, $array),
 );
 
 
@@ -53,7 +53,7 @@ Assert::same(
 		'sqlsrv' => "INSERT INTO [products]  ([pole], [bit]) VALUES (N'hodnota1', 1) , (N'hodnota2', 1) , (N'hodnota3', 1)",
 		"INSERT INTO [products]  ([pole], [bit]) VALUES ('hodnota1', 1) , ('hodnota2', 1) , ('hodnota3', 1)",
 	]),
-	$conn->translate('INSERT INTO [products] %ex', $array)
+	$conn->translate('INSERT INTO [products] %ex', $array),
 );
 
 
@@ -66,7 +66,7 @@ Assert::same(
 	$conn->translate('UPDATE [colors] SET', [
 		'color' => 'blue',
 		'order' => 12,
-	], 'WHERE [id]=%i', 123)
+	], 'WHERE [id]=%i', 123),
 );
 
 
@@ -74,20 +74,20 @@ Assert::same(
 $array = [1, 2, 3];
 Assert::same(
 	reformat('SELECT * FROM [people] WHERE [id] IN ( 1, 2, 3 )'),
-	$conn->translate('SELECT * FROM [people] WHERE [id] IN (', $array, ')')
+	$conn->translate('SELECT * FROM [people] WHERE [id] IN (', $array, ')'),
 );
 
 
 // long numbers
 Assert::same(
 	reformat('SELECT -123456789123456789123456789'),
-	$conn->translate('SELECT %i', '-123456789123456789123456789')
+	$conn->translate('SELECT %i', '-123456789123456789123456789'),
 );
 
 // long float numbers
 Assert::same(
 	reformat('SELECT -.12345678912345678912345678e10'),
-	$conn->translate('SELECT %f', '-.12345678912345678912345678e10')
+	$conn->translate('SELECT %f', '-.12345678912345678912345678e10'),
 );
 
 // invalid input
@@ -101,7 +101,7 @@ Assert::same(
 		'sqlsrv' => "SELECT * FROM [table] WHERE id=10 AND name=N'ahoj'",
 		"SELECT * FROM [table] WHERE id=10 AND name='ahoj'",
 	]),
-	$conn->translate('SELECT * FROM [table] WHERE id=%i AND name=%s', 10, 'ahoj')
+	$conn->translate('SELECT * FROM [table] WHERE id=%i AND name=%s', 10, 'ahoj'),
 );
 
 Assert::same(
@@ -109,7 +109,7 @@ Assert::same(
 		'sqlsrv' => "TEST ([cond] > 2) OR ([cond2] = N'3') OR (cond3 < RAND())",
 		"TEST ([cond] > 2) OR ([cond2] = '3') OR (cond3 < RAND())",
 	]),
-	$conn->translate('TEST %or', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()'])
+	$conn->translate('TEST %or', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()']),
 );
 
 Assert::same(
@@ -117,7 +117,7 @@ Assert::same(
 		'sqlsrv' => "TEST ([cond] > 2) AND ([cond2] = N'3') AND (cond3 < RAND())",
 		"TEST ([cond] > 2) AND ([cond2] = '3') AND (cond3 < RAND())",
 	]),
-	$conn->translate('TEST %and', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()'])
+	$conn->translate('TEST %and', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()']),
 );
 
 
@@ -126,7 +126,7 @@ $where[] = '[age] > 20';
 $where[] = '[email] IS NOT NULL';
 Assert::same(
 	reformat('SELECT * FROM [table] WHERE ([age] > 20) AND ([email] IS NOT NULL)'),
-	$conn->translate('SELECT * FROM [table] WHERE %and', $where)
+	$conn->translate('SELECT * FROM [table] WHERE %and', $where),
 );
 
 
@@ -139,14 +139,14 @@ Assert::same(
 		'sqlsrv' => "SELECT * FROM [table] WHERE ([age] IS NULL) AND ([email] = N'ahoj') AND ([id] IN (10, 20, 30))",
 		"SELECT * FROM [table] WHERE ([age] IS NULL) AND ([email] = 'ahoj') AND ([id] IN (10, 20, 30))",
 	]),
-	$conn->translate('SELECT * FROM [table] WHERE %and', $where)
+	$conn->translate('SELECT * FROM [table] WHERE %and', $where),
 );
 
 
 $where = [];
 Assert::same(
 	reformat('SELECT * FROM [table] WHERE 1=1'),
-	$conn->translate('SELECT * FROM [table] WHERE %and', $where)
+	$conn->translate('SELECT * FROM [table] WHERE %and', $where),
 );
 
 
@@ -161,7 +161,7 @@ $order = [
 ];
 Assert::same(
 	reformat('SELECT * FROM [people] ORDER BY [field1] ASC, [field2] DESC, [field3] ASC, [field4] DESC, [field5] ASC, [field6] DESC'),
-	$conn->translate('SELECT * FROM [people] ORDER BY %by', $order)
+	$conn->translate('SELECT * FROM [people] ORDER BY %by', $order),
 );
 
 
@@ -172,7 +172,7 @@ Assert::same(
 		'sqlsrv' => 'SELECT * FROM [products] OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY',
 		'SELECT * FROM [products] LIMIT 2',
 	]),
-	$conn->translate('SELECT * FROM [products] %lmt', 2)
+	$conn->translate('SELECT * FROM [products] %lmt', 2),
 );
 
 if ($config['system'] === 'odbc') {
@@ -186,7 +186,7 @@ if ($config['system'] === 'odbc') {
 			'sqlsrv' => 'SELECT * FROM [products] OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY',
 			'SELECT * FROM [products] LIMIT 2 OFFSET 1',
 		]),
-		$conn->translate('SELECT * FROM [products] %lmt %ofs', 2, 1)
+		$conn->translate('SELECT * FROM [products] %lmt %ofs', 2, 1),
 	);
 
 	// with offset = 50
@@ -197,7 +197,7 @@ if ($config['system'] === 'odbc') {
 			'sqlsrv' => 'SELECT * FROM [products] OFFSET 50 ROWS',
 			'SELECT * FROM [products] LIMIT -1 OFFSET 50',
 		]),
-		$conn->translate('SELECT * FROM [products] %ofs', 50)
+		$conn->translate('SELECT * FROM [products] %ofs', 50),
 	);
 }
 
@@ -223,7 +223,7 @@ Assert::same(
 		'b8%d' => null,
 		'b9%t' => null,
 		'c1%t' => new DateTime('1212-09-26 16:51:34.0124'),
-	])
+	]),
 );
 
 Assert::exception(function () use ($conn) {
@@ -247,13 +247,13 @@ if ($config['system'] === 'postgre') {
 	$conn->query('SET standard_conforming_strings = off');
 	Assert::same(
 		"SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\n\\\\%\\\\_\\\\\\\\''\"%'",
-		$conn->translate($args[0], $args[1], $args[2], $args[3])
+		$conn->translate($args[0], $args[1], $args[2], $args[3]),
 	);
 
 	$conn->query('SET standard_conforming_strings = on');
 	Assert::same(
 		"SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\n\\%\\_\\\\''\"%'",
-		$conn->translate($args[0], $args[1], $args[2], $args[3])
+		$conn->translate($args[0], $args[1], $args[2], $args[3]),
 	);
 } elseif ($config['driver'] !== 'sqlite') { // sqlite2
 	Assert::same(
@@ -263,7 +263,7 @@ if ($config['system'] === 'postgre') {
 			'sqlsrv' => "SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\n[%][_]\\''\"%'",
 			"SELECT * FROM products WHERE (title LIKE 'C%' AND title LIKE '%r') OR title LIKE '%a\\n\\%\\_\\\\\\\\\\'\"%'",
 		]),
-		$conn->translate($args[0], $args[1], $args[2], $args[3])
+		$conn->translate($args[0], $args[1], $args[2], $args[3]),
 	);
 }
 
@@ -274,38 +274,43 @@ $e = Assert::exception(function () use ($conn) {
 Assert::same('SELECT **Alone quote**', $e->getSql());
 
 Assert::match(
-	reformat([
-		'mysql' => "SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
-CONCAT(last_name, ', ', first_name) AS full_name
-GROUP BY `user`
-HAVING MAX(salary) > %i 123
-INTO OUTFILE '/tmp/result\\'.txt'
-FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\\\"'
-LINES TERMINATED BY '\\\\n'
-",
-		'sqlsrv' => "SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
-CONCAT(last_name, N', ', first_name) AS full_name
-GROUP BY [user]
-HAVING MAX(salary) > %i 123
-INTO OUTFILE N'/tmp/result''.txt'
-FIELDS TERMINATED BY N',' OPTIONALLY ENCLOSED BY N'\"'
-LINES TERMINATED BY N'\\n'", "SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
-CONCAT(last_name, ', ', first_name) AS full_name
-GROUP BY [user]
-HAVING MAX(salary) > %i 123
-INTO OUTFILE '/tmp/result''.txt'
-FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"'
-LINES TERMINATED BY '\\n'
-",
+	pattern: reformat([
+		'mysql' => <<<'XX'
+			SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
+			CONCAT(last_name, ', ', first_name) AS full_name
+			GROUP BY `user`
+			HAVING MAX(salary) > %i 123
+			INTO OUTFILE '/tmp/result\'.txt'
+			FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"'
+			LINES TERMINATED BY '\\n'
+			XX,
+		'sqlsrv' => <<<'XX'
+			SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
+			CONCAT(last_name, N', ', first_name) AS full_name
+			GROUP BY [user]
+			HAVING MAX(salary) > %i 123
+			INTO OUTFILE N'/tmp/result''.txt'
+			FIELDS TERMINATED BY N',' OPTIONALLY ENCLOSED BY N'"'
+			LINES TERMINATED BY N'\n'
+			XX,
+		<<<'XX'
+			SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
+			CONCAT(last_name, ', ', first_name) AS full_name
+			GROUP BY [user]
+			HAVING MAX(salary) > %i 123
+			INTO OUTFILE '/tmp/result''.txt'
+			FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+			LINES TERMINATED BY '\n'
+			XX,
 	]),
-	$conn->translate('%sql', 'SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
+	actual: $conn->translate('%sql', 'SELECT DISTINCT HIGH_PRIORITY SQL_BUFFER_RESULT
 CONCAT(last_name, ", ", first_name) AS full_name
 GROUP BY [user]
 HAVING MAX(salary) > %i', 123, "
 INTO OUTFILE '/tmp/result''.txt'
 FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"'
 LINES TERMINATED BY '\\n'
-")
+"),
 );
 
 
@@ -330,114 +335,124 @@ $array5 = ['RAND()', '[col1] > [col2]'];
 
 
 Assert::match(
-	reformat([
-		'mysql' => "SELECT *
-FROM `db`.`table`
-WHERE (`test`.`a` LIKE '1995-03-01'
-	OR `b1` IN ( 1, 2, 3 )
-	OR `b2` IN ('1', '2', '3' )
-	OR `b3` IN ( )
-	OR `b4` IN ( 'one', 'two', 'three' )
-	OR `b5` IN (`col1` AS `one`, `col2` AS `two`, `col3` AS `thr.ee` )
-	OR `b6` IN ('one', 'two', 'thr.ee')
-	OR `b7` IN (NULL)
-	OR `b8` IN (RAND() `col1` > `col2` )
-	OR `b9` IN (RAND(), [col1] > [col2] )
-	OR `b10` IN (  )
-	AND `c` = 'embedded \\' string'
-	OR `d`=10
-	OR `e`=NULL
-	OR `true`= 1
-	OR `false`= 0
-	OR `str_null`=NULL
-	OR `str_not_null`='hello'
-LIMIT 10",
-		'sqlsrv' => "SELECT *
-FROM [db].[table]
-WHERE ([test].[a] LIKE '1995-03-01'
-	OR [b1] IN ( 1, 2, 3 )
-	OR [b2] IN (N'1', N'2', N'3' )
-	OR [b3] IN ( )
-	OR [b4] IN ( N'one', N'two', N'three' )
-	OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
-	OR [b6] IN (N'one', N'two', N'thr.ee')
-	OR [b7] IN (NULL)
-	OR [b8] IN (RAND() [col1] > [col2] )
-	OR [b9] IN (RAND(), [col1] > [col2] )
-	OR [b10] IN (  )
-	AND [c] = N'embedded '' string'
-	OR [d]=10
-	OR [e]=NULL
-	OR [true]= 1
-	OR [false]= 0
-	OR [str_null]=NULL
-	OR [str_not_null]=N'hello'
-LIMIT 10",
-		'postgre' => 'SELECT *
-FROM "db"."table"
-WHERE ("test"."a" LIKE \'1995-03-01\'
-	OR "b1" IN ( 1, 2, 3 )
-	OR "b2" IN (\'1\', \'2\', \'3\' )
-	OR "b3" IN ( )
-	OR "b4" IN ( \'one\', \'two\', \'three\' )
-	OR "b5" IN ("col1" AS "one", "col2" AS "two", "col3" AS "thr.ee" )
-	OR "b6" IN (\'one\', \'two\', \'thr.ee\')
-	OR "b7" IN (NULL)
-	OR "b8" IN (RAND() "col1" > "col2" )
-	OR "b9" IN (RAND(), [col1] > [col2] )
-	OR "b10" IN (  )
-	AND "c" = \'embedded \'\' string\'
-	OR "d"=10
-	OR "e"=NULL
-	OR "true"= TRUE
-	OR "false"= FALSE
-	OR "str_null"=NULL
-	OR "str_not_null"=\'hello\'
-LIMIT 10',
-		'odbc' => "SELECT *
-FROM [db].[table]
-WHERE ([test].[a] LIKE #03/01/1995#
-	OR [b1] IN ( 1, 2, 3 )
-	OR [b2] IN ('1', '2', '3' )
-	OR [b3] IN ( )
-	OR [b4] IN ( 'one', 'two', 'three' )
-	OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
-	OR [b6] IN ('one', 'two', 'thr.ee')
-	OR [b7] IN (NULL)
-	OR [b8] IN (RAND() [col1] > [col2] )
-	OR [b9] IN (RAND(), [col1] > [col2] )
-	OR [b10] IN (  )
-	AND [c] = 'embedded '' string'
-	OR [d]=10
-	OR [e]=NULL
-	OR [true]= 1
-	OR [false]= 0
-	OR [str_null]=NULL
-	OR [str_not_null]='hello'
-LIMIT 10",
-		"SELECT *
-FROM [db].[table]
-WHERE ([test].[a] LIKE '1995-03-01'
-	OR [b1] IN ( 1, 2, 3 )
-	OR [b2] IN ('1', '2', '3' )
-	OR [b3] IN ( )
-	OR [b4] IN ( 'one', 'two', 'three' )
-	OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
-	OR [b6] IN ('one', 'two', 'thr.ee')
-	OR [b7] IN (NULL)
-	OR [b8] IN (RAND() [col1] > [col2] )
-	OR [b9] IN (RAND(), [col1] > [col2] )
-	OR [b10] IN (  )
-	AND [c] = 'embedded '' string'
-	OR [d]=10
-	OR [e]=NULL
-	OR [true]= 1
-	OR [false]= 0
-	OR [str_null]=NULL
-	OR [str_not_null]='hello'
-LIMIT 10",
+	pattern: reformat([
+		'mysql' => <<<'XX'
+			SELECT *
+			FROM `db`.`table`
+			WHERE (`test`.`a` LIKE '1995-03-01'
+				OR `b1` IN ( 1, 2, 3 )
+				OR `b2` IN ('1', '2', '3' )
+				OR `b3` IN ( )
+				OR `b4` IN ( 'one', 'two', 'three' )
+				OR `b5` IN (`col1` AS `one`, `col2` AS `two`, `col3` AS `thr.ee` )
+				OR `b6` IN ('one', 'two', 'thr.ee')
+				OR `b7` IN (NULL)
+				OR `b8` IN (RAND() `col1` > `col2` )
+				OR `b9` IN (RAND(), [col1] > [col2] )
+				OR `b10` IN (  )
+				AND `c` = 'embedded \' string'
+				OR `d`=10
+				OR `e`=NULL
+				OR `true`= 1
+				OR `false`= 0
+				OR `str_null`=NULL
+				OR `str_not_null`='hello'
+			LIMIT 10
+			XX,
+		'sqlsrv' => <<<'XX'
+			SELECT *
+			FROM [db].[table]
+			WHERE ([test].[a] LIKE '1995-03-01'
+				OR [b1] IN ( 1, 2, 3 )
+				OR [b2] IN (N'1', N'2', N'3' )
+				OR [b3] IN ( )
+				OR [b4] IN ( N'one', N'two', N'three' )
+				OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
+				OR [b6] IN (N'one', N'two', N'thr.ee')
+				OR [b7] IN (NULL)
+				OR [b8] IN (RAND() [col1] > [col2] )
+				OR [b9] IN (RAND(), [col1] > [col2] )
+				OR [b10] IN (  )
+				AND [c] = N'embedded '' string'
+				OR [d]=10
+				OR [e]=NULL
+				OR [true]= 1
+				OR [false]= 0
+				OR [str_null]=NULL
+				OR [str_not_null]=N'hello'
+			LIMIT 10
+			XX,
+		'postgre' => <<<'XX'
+			SELECT *
+			FROM "db"."table"
+			WHERE ("test"."a" LIKE '1995-03-01'
+				OR "b1" IN ( 1, 2, 3 )
+				OR "b2" IN ('1', '2', '3' )
+				OR "b3" IN ( )
+				OR "b4" IN ( 'one', 'two', 'three' )
+				OR "b5" IN ("col1" AS "one", "col2" AS "two", "col3" AS "thr.ee" )
+				OR "b6" IN ('one', 'two', 'thr.ee')
+				OR "b7" IN (NULL)
+				OR "b8" IN (RAND() "col1" > "col2" )
+				OR "b9" IN (RAND(), [col1] > [col2] )
+				OR "b10" IN (  )
+				AND "c" = 'embedded '' string'
+				OR "d"=10
+				OR "e"=NULL
+				OR "true"= TRUE
+				OR "false"= FALSE
+				OR "str_null"=NULL
+				OR "str_not_null"='hello'
+			LIMIT 10
+			XX,
+		'odbc' => <<<'XX'
+			SELECT *
+			FROM [db].[table]
+			WHERE ([test].[a] LIKE #03/01/1995#
+				OR [b1] IN ( 1, 2, 3 )
+				OR [b2] IN ('1', '2', '3' )
+				OR [b3] IN ( )
+				OR [b4] IN ( 'one', 'two', 'three' )
+				OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
+				OR [b6] IN ('one', 'two', 'thr.ee')
+				OR [b7] IN (NULL)
+				OR [b8] IN (RAND() [col1] > [col2] )
+				OR [b9] IN (RAND(), [col1] > [col2] )
+				OR [b10] IN (  )
+				AND [c] = 'embedded '' string'
+				OR [d]=10
+				OR [e]=NULL
+				OR [true]= 1
+				OR [false]= 0
+				OR [str_null]=NULL
+				OR [str_not_null]='hello'
+			LIMIT 10
+			XX,
+		<<<'XX'
+			SELECT *
+			FROM [db].[table]
+			WHERE ([test].[a] LIKE '1995-03-01'
+				OR [b1] IN ( 1, 2, 3 )
+				OR [b2] IN ('1', '2', '3' )
+				OR [b3] IN ( )
+				OR [b4] IN ( 'one', 'two', 'three' )
+				OR [b5] IN ([col1] AS [one], [col2] AS [two], [col3] AS [thr.ee] )
+				OR [b6] IN ('one', 'two', 'thr.ee')
+				OR [b7] IN (NULL)
+				OR [b8] IN (RAND() [col1] > [col2] )
+				OR [b9] IN (RAND(), [col1] > [col2] )
+				OR [b10] IN (  )
+				AND [c] = 'embedded '' string'
+				OR [d]=10
+				OR [e]=NULL
+				OR [true]= 1
+				OR [false]= 0
+				OR [str_null]=NULL
+				OR [str_not_null]='hello'
+			LIMIT 10
+			XX,
 	]),
-	$conn->translate('SELECT *
+	actual: $conn->translate('SELECT *
 FROM [db.table]
 WHERE ([test.a] LIKE %d', '1995-03-01', '
 	OR [b1] IN (', $array1, ')
@@ -457,7 +472,7 @@ WHERE ([test.a] LIKE %d', '1995-03-01', '
 	OR [false]=', false, '
 	OR [str_null]=%sn', '', '
 	OR [str_not_null]=%sn', 'hello', '
-LIMIT 10')
+LIMIT 10'),
 );
 
 
@@ -466,19 +481,19 @@ Assert::same(
 		'sqlsrv' => "TEST  [cond] > 2 [cond2] = N'3' cond3 < RAND() 123",
 		"TEST  [cond] > 2 [cond2] = '3' cond3 < RAND() 123",
 	]),
-	$conn->translate('TEST %ex', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()'], 123)
+	$conn->translate('TEST %ex', ['[cond] > 2', '[cond2] = "3"', 'cond3 < RAND()'], 123),
 );
 
 
 Assert::same(
 	reformat('TEST ([cond] > 2) OR ([cond2] > 3) OR ([cond3] = 10 + 1)'),
-	$conn->translate('TEST %or', ['`cond` > 2', ['[cond2] > %i', '3'], 'cond3%sql' => ['10 + 1']])
+	$conn->translate('TEST %or', ['`cond` > 2', ['[cond2] > %i', '3'], 'cond3%sql' => ['10 + 1']]),
 );
 
 
 Assert::same(
 	reformat('TEST ([cond] = 2) OR ([cond3] = RAND())'),
-	$conn->translate('TEST %or', ['cond' => 2, 'cond3%sql' => 'RAND()'])
+	$conn->translate('TEST %or', ['cond' => 2, 'cond3%sql' => 'RAND()']),
 );
 
 
@@ -487,7 +502,7 @@ Assert::same(
 		'sqlsrv' => "TEST ([cond1] 3) OR ([cond2] RAND()) OR ([cond3] LIKE N'string')",
 		"TEST ([cond1] 3) OR ([cond2] RAND()) OR ([cond3] LIKE 'string')",
 	]),
-	$conn->translate('TEST %or', ['cond1%ex' => 3, 'cond2%ex' => 'RAND()', 'cond3%ex' => ['LIKE %s', 'string']])
+	$conn->translate('TEST %or', ['cond1%ex' => 3, 'cond2%ex' => 'RAND()', 'cond3%ex' => ['LIKE %s', 'string']]),
 );
 
 
@@ -497,7 +512,7 @@ Assert::same(
 		'sqlsrv' => 'SELECT * FROM [test] WHERE [id] LIKE N\'%d%t\' OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY',
 		'SELECT * FROM [test] WHERE [id] LIKE \'%d%t\' LIMIT 10',
 	]),
-	$conn->translate("SELECT * FROM [test] WHERE %n LIKE '%d%t' %lmt", 'id', 10)
+	$conn->translate("SELECT * FROM [test] WHERE %n LIKE '%d%t' %lmt", 'id', 10),
 );
 
 
@@ -506,13 +521,13 @@ $where = [
 ];
 Assert::same(
 	reformat('SELECT * FROM [tablename] WHERE ([tablename].[column] = 1)'),
-	$conn->translate('SELECT * FROM [tablename] WHERE %and', $where)
+	$conn->translate('SELECT * FROM [tablename] WHERE %and', $where),
 );
 
 
 Assert::same(
 	reformat('SELECT FROM ...'),
-	$conn->translate('SELECT FROM ... %lmt', null)
+	$conn->translate('SELECT FROM ... %lmt', null),
 );
 
 Assert::same(
@@ -520,7 +535,7 @@ Assert::same(
 		'sqlsrv' => "SELECT N'%i'",
 		"SELECT '%i'",
 	]),
-	$conn->translate("SELECT '%i'")
+	$conn->translate("SELECT '%i'"),
 );
 
 Assert::same(
@@ -528,7 +543,7 @@ Assert::same(
 		'sqlsrv' => "SELECT N'%i'",
 		"SELECT '%i'",
 	]),
-	$conn->translate('SELECT "%i"')
+	$conn->translate('SELECT "%i"'),
 );
 
 
@@ -543,7 +558,7 @@ Assert::same(
 	], [
 		'product_id' => 1,
 		'title' => new Dibi\Expression('SHA1(%s)', 'Test product'),
-	])
+	]),
 );
 
 Assert::same(
@@ -554,7 +569,7 @@ Assert::same(
 	$conn->translate('UPDATE [products]', [
 		'product_id' => 1,
 		'title' => new Dibi\Expression('SHA1(%s)', 'Test product'),
-	])
+	]),
 );
 
 Assert::same(
@@ -565,7 +580,7 @@ Assert::same(
 	$conn->translate('UPDATE [products]', [
 		'product_id' => 1,
 		'title' => new Dibi\Expression('SHA1(%s)', 'Test product'),
-	])
+	]),
 );
 
 Assert::same(
@@ -576,7 +591,7 @@ Assert::same(
 	$conn->translate('SELECT * FROM [products] WHERE', [
 		'product_id' => 1,
 		'title' => new Dibi\Expression('SHA1(%s)', 'Test product'),
-	])
+	]),
 );
 
 
@@ -588,7 +603,7 @@ Assert::same(
 			'top' => 2,
 		]),
 		new Dibi\Expression('number < %i', 100),
-	])
+	]),
 );
 
 
@@ -613,7 +628,7 @@ Assert::same(
 		'sqlsrv' => "INSERT INTO test ([id], [text], [num]) VALUES (1, N'ahoj', 1), (2, N'jak', -1), (3, N'se', 10), (4, SUM(5), 1)",
 		"INSERT INTO test ([id], [text], [num]) VALUES (1, 'ahoj', 1), (2, 'jak', -1), (3, 'se', 10), (4, SUM(5), 1)",
 	]),
-	$conn->translate('INSERT INTO test %m', $array6)
+	$conn->translate('INSERT INTO test %m', $array6),
 );
 
 
@@ -624,12 +639,12 @@ $by = [
 
 Assert::same(
 	reformat('SELECT * FROM table ORDER BY funkce(nazev_pole) ASC, [jine_pole] DESC'),
-	$conn->translate('SELECT * FROM table ORDER BY %by', $by)
+	$conn->translate('SELECT * FROM table ORDER BY %by', $by),
 );
 
 Assert::same(
 	reformat('INSERT INTO [test].*'),
-	$conn->translate('INSERT INTO [test.*]')
+	$conn->translate('INSERT INTO [test.*]'),
 );
 
 Assert::exception(function () use ($conn) {
@@ -643,23 +658,23 @@ Assert::exception(function () use ($conn) {
 
 Assert::same(
 	reformat('SELECT * FROM table'),
-	$conn->translate('SELECT', new Dibi\Literal('* FROM table'))
+	$conn->translate('SELECT', new Dibi\Literal('* FROM table')),
 );
 
 Assert::same(
 	reformat('SELECT * FROM table'),
-	$conn->translate('SELECT %SQL', new Dibi\Literal('* FROM table'))
+	$conn->translate('SELECT %SQL', new Dibi\Literal('* FROM table')),
 );
 
 Assert::same(
 	reformat('SELECT * FROM table'),
-	$conn->translate(new Dibi\Literal('SELECT * FROM table'))
+	$conn->translate(new Dibi\Literal('SELECT * FROM table')),
 );
 
 
 Assert::same(
 	reformat('SELECT [a].[b] AS [c.d]'),
-	$conn->translate('SELECT %n AS %N', 'a.b', 'c.d')
+	$conn->translate('SELECT %n AS %N', 'a.b', 'c.d'),
 );
 
 
@@ -677,5 +692,5 @@ Assert::same(
 		'spec2%f' => 1000.00,
 		'spec3%i' => 10000,
 		'spec4' => 10000,
-	], 'WHERE [price]=%f', 123.5)
+	], 'WHERE [price]=%f', 123.5),
 );


### PR DESCRIPTION
- new feature, no existing code will break (full bc)

I added support for PDO in `PDO::ERRMODE_EXCEPTION` error mode using a single try-catch block.

👉 Since in PHP 8 `PDO::ERRMODE_EXCEPTION` is the default error mode!
