### PR TITLE
PostgreReflector: fix reflection of matview columns on PostgreSQL 12+

### DIFF
--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -100,7 +100,7 @@ class PostgreReflector implements Dibi\Reflector
 					a.atttypmod-4 AS character_maximum_length,
 					NOT a.attnotnull AS is_nullable,
 					a.attnum AS ordinal_position,
-					adef.adsrc AS column_default
+					pg_get_expr(adef.adbin, adef.adrelid) AS column_default
 				FROM
 					pg_attribute a
 					JOIN pg_type ON a.atttypid = pg_type.oid


### PR DESCRIPTION
- bug fix
- BC break? no

On PostgreSQL 12, the system catalog has changed in a way that is incompatible with dibi's query to obtain column metadata of materialized views. Column `pg_attrdef`.`adsrc` is no longer provided by the system catalog, and has to be replaced by a function call using `pg_get_expr` instead. Fortunately, `pg_get_expr` is available in all relevant PostgreSQL versions and can thus be safely used here without causing a BC break.

This issue affects all current versions of dibi, but only in combination with PostgreSQL version 12 or newer.