### PR TITLE
Helpers::detectType(): detect PostgreSQL range types as Type::TEXT

### DIFF
--- a/src/Dibi/Helpers.php
+++ b/src/Dibi/Helpers.php
@@ -179,6 +179,7 @@ class Helpers
 	{
 		static $patterns = [
 			'^_' => Type::TEXT, // PostgreSQL arrays
+			'RANGE$' => Type::TEXT, // PostgreSQL range types
 			'BYTEA|BLOB|BIN' => Type::BINARY,
 			'TEXT|CHAR|POINT|INTERVAL|STRING' => Type::TEXT,
 			'YEAR|BYTE|COUNTER|SERIAL|INT|LONG|SHORT|^TINY$' => Type::INTEGER,


### PR DESCRIPTION
- bug fix
- BC break? probably not

Dibi is currently unable to handle [PostgreSQL range types](https://www.postgresql.org/docs/current/rangetypes.html), as it attempts to convert their values into single-value data types such as a float/int or a DateTime. This is logically not possible and results in TypeError or Exception, depending on the type:
`DateTime::__construct(): Failed to parse time string ((,)) at position 0 ((): Unexpected character`
For example int4range contains values such as `[2,3)` or `empty`, so it is also impossible to convert into a single numeric type.

I think a reasonable solution is to use the same approach as with PostgreSQL arrays and simply treat all range types as `Type::TEXT`. This will keep the raw range value intact and avoid typecasting errors.

Although this is a change in type detection behavior, I wouldn't consider it a BC break, since range types effectively aren't functional at all without this change.