### PR TITLE
Translator: convert BackedEnum to scalar

### DIFF
--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -457,6 +457,10 @@ final class Translator
 			}
 		}
 
+		// object-to-scalar procession
+		if ($value instanceof \BackedEnum && is_scalar($value->value)) {
+			$value = $value->value;
+		}
 
 		// without modifier procession
 		if (is_string($value)) {

--- a/tests/dibi/Translator.enums.phpt
+++ b/tests/dibi/Translator.enums.phpt
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @phpVersion >= 8.1
+ * @dataProvider ../databases.ini
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+$conn = new Dibi\Connection($config);
+$translator = new Dibi\Translator($conn);
+
+
+enum EnumInt: int
+{
+	case One = 1;
+}
+
+enum EnumString: string
+{
+	case One = 'one';
+}
+
+enum PureEnum
+{
+	case One;
+}
+
+
+Assert::equal('1', $translator->formatValue(EnumInt::One, null));
+
+Assert::equal(match ($config['driver']) {
+	'sqlsrv' => "N'one'",
+	default => "'one'",
+}, $translator->formatValue(EnumString::One, null));
+
+Assert::equal('**Unexpected PureEnum**', $translator->formatValue(PureEnum::One, null));


### PR DESCRIPTION
- new feature
- BC break? no

Backed enumerations are translated to their scalar values.