### PR TITLE
MySqliDriver::getResource() fixed usage of resource being closed prior to the call in PHP 8

### DIFF
--- a/src/Dibi/Drivers/MySqliDriver.php
+++ b/src/Dibi/Drivers/MySqliDriver.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Dibi\Drivers;
 
 use Dibi;
+use Throwable;
 
 
 /**
@@ -246,7 +247,11 @@ class MySqliDriver implements Dibi\Driver
 	 */
 	public function getResource(): ?\mysqli
 	{
-		return @$this->connection->thread_id ? $this->connection : null;
+		try {
+			return @$this->connection->thread_id ? $this->connection : null;
+		} catch (Throwable $e) {
+			return null;
+		}
 	}
 
 

--- a/tests/databases.appveyor.ini
+++ b/tests/databases.appveyor.ini
@@ -23,6 +23,14 @@ username = root
 password = "Password12!"
 system = mysql
 
+[mysqli-driver]
+driver = mysqli
+host = 127.0.0.1
+username = root
+password = "Password12!"
+charset = utf8
+system = mysql
+
 [odbc]
 driver = odbc
 dsn = "Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=data/odbc.mdb"

--- a/tests/databases.github.ini
+++ b/tests/databases.github.ini
@@ -40,6 +40,15 @@ user = root
 password = root
 system = mysql
 
+[mysqli-driver]
+driver = mysqli
+host = "127.0.0.1"
+database = dibi_test
+username = root
+password = root
+port = 3307
+system = mysql
+
 [postgre 9.6]
 driver = postgre
 host = "127.0.0.1"

--- a/tests/dibi/Driver.mysqli.phpt
+++ b/tests/dibi/Driver.mysqli.phpt
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Dibi\Drivers\MySqliDriver;
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+//$rc = new \mysqli(
+//	$config['host'],
+//	$config['username'],
+//	$config['password'],
+//	$config['database'],
+//	$config['port'],
+//);
+$rc = new \mysqli(
+	"127.0.0.1",
+	'root',
+	'root',
+	'dibi_test',
+	3306,
+);
+
+$driver = new MySqliDriver([
+	'resource' => $rc,
+]);
+
+// sanity check
+Assert::same($rc, $driver->getResource());
+
+// close the connection
+$rc->close();
+
+// This would trigger an error in PHP 8, see #409
+Assert::null($driver->getResource());


### PR DESCRIPTION
closes #409
