### PR TITLE
PostgreReflector: fix autoincrement column detection

### DIFF
--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -94,7 +94,8 @@ class PostgreReflector implements Dibi\Reflector
 					a.atttypmod-4 AS character_maximum_length,
 					NOT a.attnotnull AS is_nullable,
 					a.attnum AS ordinal_position,
-					pg_get_expr(adef.adbin, adef.adrelid) AS column_default
+					pg_get_expr(adef.adbin, adef.adrelid) AS column_default,
+					CASE WHEN a.attidentity IN ('a', 'd') THEN 'YES' ELSE 'NO' END AS is_identity
 				FROM
 					pg_attribute a
 					JOIN pg_type ON a.atttypid = pg_type.oid
@@ -119,7 +120,7 @@ class PostgreReflector implements Dibi\Reflector
 				'size' => $size > 0 ? $size : null,
 				'nullable' => $row['is_nullable'] === 'YES' || $row['is_nullable'] === 't' || $row['is_nullable'] === true,
 				'default' => $row['column_default'],
-				'autoincrement' => str_starts_with($row['column_default'] ?? '', 'nextval('),
+				'autoincrement' => $row['is_identity'] === 'YES' || str_starts_with($row['column_default'] ?? '', 'nextval('),
 				'vendor' => $row,
 			];
 		}

--- a/src/Dibi/Drivers/PostgreReflector.php
+++ b/src/Dibi/Drivers/PostgreReflector.php
@@ -75,13 +75,6 @@ class PostgreReflector implements Dibi\Reflector
 	public function getColumns(string $table): array
 	{
 		$_table = $this->driver->escapeText($this->driver->escapeIdentifier($table));
-		$res = $this->driver->query("
-			SELECT indkey
-			FROM pg_class
-			LEFT JOIN pg_index on pg_class.oid = pg_index.indrelid AND pg_index.indisprimary
-			WHERE pg_class.oid = $_table::regclass
-		");
-		$primary = (int) $res->fetch(true)['indkey'];
 
 		$res = $this->driver->query("
 			SELECT *
@@ -126,7 +119,7 @@ class PostgreReflector implements Dibi\Reflector
 				'size' => $size > 0 ? $size : null,
 				'nullable' => $row['is_nullable'] === 'YES' || $row['is_nullable'] === 't' || $row['is_nullable'] === true,
 				'default' => $row['column_default'],
-				'autoincrement' => (int) $row['ordinal_position'] === $primary && str_starts_with($row['column_default'] ?? '', 'nextval'),
+				'autoincrement' => str_starts_with($row['column_default'] ?? '', 'nextval('),
 				'vendor' => $row,
 			];
 		}


### PR DESCRIPTION
- bug fix
- BC break? probably not
- versions affected: all

When an autoincrement column is not in the first position of primary key index, PostgreReflector is unable to detect it. This seems like a rather arbitrary check, which is also inconsistent with other drivers such as MySqlReflector; MySqlReflector doesn't require autoincrement columns to be part of a primary key at all to detect them.

My commit removes the primary key check from PostgreReflector autoincrement detection entirely, making it consistent with MySqlReflector and allowing PostgreReflector to detect autoincrement columns anywhere in the table.

This is potentially a BC break for someone who relies on PostgreReflector's failure to detect autoincrement columns outside the first position of primary key index.

Additionally, I've made the autoincrement check stricter in that the column's default value must start with `nextval(` instead of only `nextval`. This prevents potential false positives when a column's default value would be set to invoke some custom function like `nextvalentine()`.
