### PR TITLE
Panel: move escape sequence to double-quoted string

### DIFF
--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -156,7 +156,7 @@ class Panel implements Tracy\IBarPanel
 		return '<style> #tracy-debug td.tracy-DibiProfiler-sql { background: white !important }
 			#tracy-debug .tracy-DibiProfiler-source { color: #999 !important }
 			#tracy-debug tracy-DibiProfiler tr table { margin: 8px 0; max-height: 150px; overflow:auto } </style>
-			<h1>Queries:\u{a0}' . count($this->events)
+			<h1>Queries:' . "\u{a0}" . count($this->events)
 				. ($totalTime === null ? '' : ", time:\u{a0}" . number_format($totalTime * 1000, 1, '.', "\u{202f}") . "\u{202f}ms") . ', '
 				. htmlspecialchars($this->getConnectionName($singleConnection)) . '</h1>
 			<div class="tracy-inner tracy-DibiProfiler">


### PR DESCRIPTION
- bug fix
- BC break? no

Non-breakable space entity in Tracy panel markup was converted to `\u{a0}` escape sequence, however it was kept inside of single quoted string, which prevents it from being recognized as an escape sequence and results in text `\u{a0}` being output into the Dibi Tracy panel heading.

Affected versions: only 4.2.6

![image](https://user-images.githubusercontent.com/8158773/177105794-6a0c8d66-2a04-4a03-955a-bb1409a7b7dd.png)