### PR TITLE
Detecting event source without filesystem checks

### DIFF
--- a/src/Dibi/Event.php
+++ b/src/Dibi/Event.php
@@ -63,7 +63,11 @@ class Event
 
 		$dibiDir = dirname((new \ReflectionClass('dibi'))->getFileName()) . DIRECTORY_SEPARATOR;
 		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $row) {
-			if (isset($row['file']) && is_file($row['file']) && !str_starts_with($row['file'], $dibiDir)) {
+			if (
+				isset($row['file'])
+				&& !str_starts_with($row['file'], $dibiDir)
+				&& !str_ends_with($row['file'], ": eval()'d code")
+			) {
 				$this->source = [$row['file'], (int) $row['line']];
 				break;
 			}

--- a/tests/dibi/Event.source.phpt
+++ b/tests/dibi/Event.source.phpt
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @dataProvider ../databases.ini
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+$conn = new Dibi\Connection($config);
+
+$event = new Dibi\Event($conn, Dibi\Event::CONNECT);
+Assert::same([__FILE__, __LINE__ - 1], $event->source);
+
+eval('$event = new Dibi\Event($conn, Dibi\Event::CONNECT);');
+Assert::same([__FILE__, __LINE__ - 1], $event->source);
+
+array_map(function () use ($conn) {
+	$event = new Dibi\Event($conn, Dibi\Event::CONNECT);
+	Assert::same([__FILE__, __LINE__ - 1], $event->source);
+}, [null]);


### PR DESCRIPTION
Got rid of filesystem (OS stat) checks per each event.
https://github.com/dg/dibi/issues/426
