### PR TITLE
SqLite: Fix fatal error when resource closed prior to result destructing

### DIFF
--- a/src/Dibi/Drivers/SqliteResult.php
+++ b/src/Dibi/Drivers/SqliteResult.php
@@ -38,7 +38,7 @@ class SqliteResult implements Dibi\ResultDriver
 	 */
 	public function __destruct()
 	{
-		if ($this->autoFree && $this->getResultResource()) {
+		if ($this->autoFree && is_resource($this->getResultResource())) {
 			@$this->free();
 		}
 	}


### PR DESCRIPTION
Bug fix; bc break: NO.

Same as #430 for v4.2