### PR TITLE
Object translator No.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,16 @@ cache:
 
 clone_folder: c:\projects\dibi
 
+environment:
+    MYSQL_PWD: Password12!
+
 services:
     - mssql2012sp1
 #    - mssql2014
     - mysql
 
 init:
-    - SET PATH=c:\php;%PATH%
+    - SET PATH=c:\php;c:\Program Files\MySQL\MySQL Server 5.7\bin;%PATH%
     - SET ANSICON=121x90 (121x90)
 
 install:
@@ -39,6 +42,10 @@ install:
 
     # Create databases.ini
     - copy tests\databases.appveyor.ini tests\databases.ini
+
+before_test:
+    # Create MySQL database
+    - mysql --user=root -e "CREATE DATABASE dibi_test"
 
 test_script:
     - vendor\bin\tester tests -s -p c:\php\php -c tests\php-win.ini

--- a/src/Dibi/Connection.php
+++ b/src/Dibi/Connection.php
@@ -35,6 +35,11 @@ class Connection implements IConnection
 
 	private ?Translator $translator = null;
 
+	/** @var array<string, callable(object): Expression | null> */
+	private array $translators = [];
+
+	private bool $sortTranslators = false;
+
 	private HashMap $substitutes;
 
 	private int $transactionDepth = 0;
@@ -519,6 +524,59 @@ class Connection implements IConnection
 		return str_contains($value, ':')
 			? preg_replace_callback('#:([^:\s]*):#', fn(array $m) => $this->substitutes->{$m[1]}, $value)
 			: $value;
+	}
+
+
+	/********************* value objects translation ****************d*g**/
+
+
+	/**
+	 * @param  callable(object): Expression  $translator
+	 */
+	public function setObjectTranslator(string $class, callable $translator): void
+	{
+		$this->translators[$class] = $translator;
+		$this->sortTranslators = true;
+	}
+
+
+	public function translateObject(object $object): ?Expression
+	{
+		if ($this->sortTranslators) {
+			$this->translators = array_filter($this->translators);
+			uksort($this->translators, fn($a, $b) => is_subclass_of($a, $b) ? -1 : 1);
+			$this->sortTranslators = false;
+		}
+
+		if (array_key_exists($object::class, $this->translators)) {
+			$translator = $this->translators[$object::class];
+
+		} else {
+			$translator = null;
+			foreach ($this->translators as $class => $t) {
+				if ($object instanceof $class) {
+					$translator = $t;
+					break;
+				}
+			}
+			$this->translators[$object::class] = $translator;
+		}
+
+		if ($translator === null) {
+			return null;
+		}
+
+		$result = $translator($object);
+		if (!$result instanceof Expression) {
+			throw new Exception(sprintf(
+				"Object translator for class '%s' returned '%s' but %s expected.",
+				$object::class,
+				get_debug_type($result),
+				Expression::class,
+			));
+		}
+
+		return $result;
 	}
 
 

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -314,6 +314,15 @@ final class Translator
 			}
 		}
 
+		if (is_object($value)
+			&& $modifier === null
+			&& !$value instanceof Literal
+			&& !$value instanceof Expression
+			&& $result = $this->connection->translateObject($value)
+		) {
+			return $this->connection->translate(...$result->getValues());
+		}
+
 		// object-to-scalar procession
 		if ($value instanceof \BackedEnum && is_scalar($value->value)) {
 			$value = $value->value;

--- a/tests/databases.appveyor.ini
+++ b/tests/databases.appveyor.ini
@@ -13,12 +13,13 @@ driver = mysqli
 host = 127.0.0.1
 username = root
 password = "Password12!"
+database = dibi_test
 charset = utf8
 system = mysql
 
 [mysql pdo]
 driver = pdo
-dsn = "mysql:host=127.0.0.1"
+dsn = "mysql:host=127.0.0.1;dbname=dibi_test"
 username = root
 password = "Password12!"
 system = mysql

--- a/tests/databases.sample.ini
+++ b/tests/databases.sample.ini
@@ -13,12 +13,13 @@ driver = mysqli
 host = 127.0.0.1
 username = root
 password =
+database = dibi_test
 charset = utf8
 system = mysql
 
 [mysql pdo]
 driver = pdo
-dsn = "mysql:host=127.0.0.1"
+dsn = "mysql:host=127.0.0.1;dbname=dibi_test"
 username = root
 password =
 system = mysql

--- a/tests/dibi/Connection.objectTranslator.phpt
+++ b/tests/dibi/Connection.objectTranslator.phpt
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * @dataProvider ../databases.ini
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+$conn = new Dibi\Connection($config + ['formatDateTime' => "'Y-m-d H:i:s.u'", 'formatDate' => "'Y-m-d'"]);
+
+
+class Email
+{
+	public $address = 'address@example.com';
+}
+
+class Time extends DateTimeImmutable
+{
+}
+
+
+test('Without object translator', function () use ($conn) {
+	Assert::exception(function () use ($conn) {
+		$conn->translate('?', new Email);
+	}, Dibi\Exception::class, 'SQL translate error: Unexpected Email');
+});
+
+
+test('Basics', function () use ($conn) {
+	$conn->setObjectTranslator(
+		Email::class,
+		fn(Email $email) => new Dibi\Expression('?', $email->address),
+	);
+	Assert::same(
+		reformat([
+			'sqlsrv' => "N'address@example.com'",
+			"'address@example.com'",
+		]),
+		$conn->translate('?', new Email),
+	);
+});
+
+
+test('DateTime', function () use ($conn) {
+	$stamp = Time::createFromFormat('Y-m-d H:i:s', '2022-11-22 12:13:14');
+
+	// Without object translator, DateTime child is translated by driver
+	Assert::same(
+		$conn->getDriver()->escapeDateTime($stamp),
+		$conn->translate('?', $stamp),
+	);
+
+
+	// With object translator
+	$conn->setObjectTranslator(
+		Time::class,
+		fn(Time $time) => new Dibi\Expression('OwnTime(?)', $time->format('H:i:s')),
+	);
+	Assert::same(
+		reformat([
+			'sqlsrv' => "OwnTime(N'12:13:14')",
+			"OwnTime('12:13:14')",
+		]),
+		$conn->translate('?', $stamp),
+	);
+
+
+	// With modifier, it is still translated by driver
+	Assert::same(
+		$conn->getDriver()->escapeDateTime($stamp),
+		$conn->translate('%dt', $stamp),
+	);
+	Assert::same(
+		$conn->getDriver()->escapeDateTime($stamp),
+		$conn->translate('%t', $stamp),
+	);
+	Assert::same(
+		$conn->getDriver()->escapeDate($stamp),
+		$conn->translate('%d', $stamp),
+	);
+
+
+	// DateTimeImmutable as a Time parent is not affected and still translated by driver
+	$dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2022-11-22 12:13:14');
+	Assert::same(
+		$conn->getDriver()->escapeDateTime($dt),
+		$conn->translate('?', $dt),
+	);
+
+	// But DateTime translation can be overloaded
+	$conn->setObjectTranslator(
+		DateTimeInterface::class,
+		fn (DateTimeInterface $dt) => new Dibi\Expression('OwnDateTime'),
+	);
+	Assert::same(
+		'OwnDateTime',
+		$conn->translate('?', $dt),
+	);
+});
+
+
+test('Complex structures', function () use ($conn) {
+	$conn->setObjectTranslator(Email::class, fn(Email $email) => new Dibi\Expression('?', $email->address));
+	$conn->setObjectTranslator(Time::class, fn (Time $time) => new Dibi\Expression('OwnTime(?)', $time->format('H:i:s')));
+	$conn->setObjectTranslator(DateTimeInterface::class, fn (DateTimeInterface $dt) => new Dibi\Expression('OwnDateTime'));
+
+	$time = Time::createFromFormat('Y-m-d H:i:s', '2022-11-22 12:13:14');
+	Assert::same(
+		reformat([
+			'sqlsrv' => "([a], [b], [c], [d], [e], [f], [g]) VALUES (OwnTime(N'12:13:14'), '2022-11-22', CONVERT(DATETIME2(7), '2022-11-22 12:13:14.000000'), CONVERT(DATETIME2(7), '2022-11-22 12:13:14.000000'), N'address@example.com', OwnDateTime, OwnDateTime)",
+			'odbc' => "([a], [b], [c], [d], [e], [f], [g]) VALUES (OwnTime('12:13:14'), #11/22/2022#, #11/22/2022 12:13:14.000000#, #11/22/2022 12:13:14.000000#, 'address@example.com', OwnDateTime, OwnDateTime)",
+			"([a], [b], [c], [d], [e], [f], [g]) VALUES (OwnTime('12:13:14'), '2022-11-22', '2022-11-22 12:13:14.000000', '2022-11-22 12:13:14.000000', 'address@example.com', OwnDateTime, OwnDateTime)",
+		]),
+		$conn->translate('%v', [
+			'a' => $time,
+			'b%d' => $time,
+			'c%t' => $time,
+			'd%dt' => $time,
+			'e' => new Email,
+			'f' => new DateTime,
+			'g' => new DateTimeImmutable,
+		]),
+	);
+});
+
+
+test('Invalid translator', function () use ($conn) {
+	$conn->setObjectTranslator(
+		Email::class,
+		fn(Email $email) => 'foo',
+	);
+
+	Assert::exception(
+		fn() => $conn->translate('?', new Email),
+		Dibi\Exception::class, "Object translator for class 'Email' returned 'string' but Dibi\Expression expected.",
+	);
+});

--- a/tests/dibi/data/mysql.sql
+++ b/tests/dibi/data/mysql.sql
@@ -1,8 +1,7 @@
-DROP DATABASE IF EXISTS dibi_test;
-CREATE DATABASE dibi_test;
-USE dibi_test;
-
+DROP TABLE IF EXISTS `orders`;
 DROP TABLE IF EXISTS `products`;
+DROP TABLE IF EXISTS `customers`;
+
 CREATE TABLE `products` (
 	`product_id` int(11) NOT NULL AUTO_INCREMENT,
 	`title` varchar(100) NOT NULL,
@@ -15,7 +14,6 @@ INSERT INTO `products` (`product_id`, `title`) VALUES
 (3, 'Computer'),
 (2, 'Table');
 
-DROP TABLE IF EXISTS `customers`;
 CREATE TABLE `customers` (
 	`customer_id` int(11) NOT NULL AUTO_INCREMENT,
 	`name` varchar(100) NOT NULL,
@@ -30,7 +28,6 @@ INSERT INTO `customers` (`customer_id`, `name`) VALUES
 (5, 'Kryten'),
 (6, 'Kristine Kochanski');
 
-DROP TABLE IF EXISTS `orders`;
 CREATE TABLE `orders` (
 	`order_id` int(11) NOT NULL AUTO_INCREMENT,
 	`customer_id` int(11) NOT NULL,

--- a/tests/dibi/meta.phpt
+++ b/tests/dibi/meta.phpt
@@ -19,12 +19,11 @@ try {
 	Tester\Environment::skip($e->getMessage());
 }
 
-if ($config['system'] !== 'sqlsrv') {
-	Assert::same(3, count($meta->getTables()));
-	$names = $meta->getTableNames();
-	sort($names);
-	Assert::equal(['customers', 'orders', 'products'], $names);
-}
+$tableNames = $meta->getTableNames();
+Assert::true(in_array('customers', $tableNames, true));
+Assert::true(in_array('orders', $tableNames, true));
+Assert::true(in_array('products', $tableNames, true));
+
 
 Assert::false($meta->hasTable('xxxx'));
 

--- a/tests/dibi/mysql.time.phpt
+++ b/tests/dibi/mysql.time.phpt
@@ -12,7 +12,6 @@ require __DIR__ . '/bootstrap.php';
 
 $conn = new Dibi\Connection($config);
 
-$conn->query('USE dibi_test');
 $conn->query('DROP TABLE IF EXISTS timetest');
 $conn->query('CREATE TABLE timetest (col TIME NOT NULL) ENGINE=InnoDB');
 $conn->query('INSERT INTO timetest VALUES ("12:30:40")');


### PR DESCRIPTION
Another approach of #429

API is:
```php
Connection::setObjectTranslator(string $class, callable $translator): void

# e.g.
$connection->setObjectTranslator(Email::class, fn($email) => new Expression('?', $email->address));
```

If you consider it useful, last commit changes API and the target class is detected from `$translator` parameter typehint:
```php
Connection::setObjectTranslator(callable $translator): void

# e.g.
$connection->setObjectTranslator(fn(Email $email) => new Expression('?', $email->address));
```