### PR TITLE
Update readme.md, fixes `transaction` method name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -341,7 +341,7 @@ $database->query('INSERT INTO users', [
 There are three methods for dealing with transactions:
 
 ```php
-$database->beginTransaction();
+$database->begin();
 
 $database->commit();
 


### PR DESCRIPTION
fixes transaction method name

- bug fix
- BC break? no

There's no `beginTransaction` method.

```plain
LogicException: Call to undefined method Dibi\Connection::beginTransaction()
```