### PR TITLE
Dibi\Exception::__construct(): Argument #2 ($code) must be of type string|int, null given fix

### DIFF
--- a/src/Dibi/Drivers/PdoDriver.php
+++ b/src/Dibi/Drivers/PdoDriver.php
@@ -93,6 +93,7 @@ class PdoDriver implements Dibi\Driver
 		$this->affectedRows = null;
 
 		[$sqlState, $code, $message] = $this->connection->errorInfo();
+		$code ??= 0;
 		$message = "SQLSTATE[$sqlState]: $message";
 		switch ($this->driverName) {
 			case 'mysql':
@@ -139,7 +140,7 @@ class PdoDriver implements Dibi\Driver
 	{
 		if (!$this->connection->beginTransaction()) {
 			$err = $this->connection->errorInfo();
-			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1]);
+			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1] ?? 0);
 		}
 	}
 
@@ -152,7 +153,7 @@ class PdoDriver implements Dibi\Driver
 	{
 		if (!$this->connection->commit()) {
 			$err = $this->connection->errorInfo();
-			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1]);
+			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1] ?? 0);
 		}
 	}
 
@@ -165,7 +166,7 @@ class PdoDriver implements Dibi\Driver
 	{
 		if (!$this->connection->rollBack()) {
 			$err = $this->connection->errorInfo();
-			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1]);
+			throw new Dibi\DriverException("SQLSTATE[$err[0]]: $err[2]", $err[1] ?? 0);
 		}
 	}
 


### PR DESCRIPTION
- bug fix / new feature?   yes
- BC break? no

I've encountered this exception on production:
![image](https://github.com/dg/dibi/assets/617880/e9762470-337e-4cca-8c86-9eac0490c0b0)

It is a PDO connecting to the SQL Server. I dug into it and found out, that [PDO::errorInfo](https://www.php.net/manual/en/pdo.errorinfo.php) could return NULL for array keys > 0 (driver-specific code and message), but Exceptions do not accept NULL as a code.
![image](https://github.com/dg/dibi/assets/617880/abd51f29-fc2a-4458-975d-50c1091c092b)

This PR fix the issue but assigning code to 0 when the method returns NUL in code.
