### PR TITLE
Add mixed type hint for magic properties

### DIFF
--- a/src/Dibi/Row.php
+++ b/src/Dibi/Row.php
@@ -48,6 +48,9 @@ class Row implements \ArrayAccess, \IteratorAggregate, \Countable
 	}
 
 
+	/**
+	 * @return mixed
+	 */
 	public function __get(string $key)
 	{
 		$hint = Helpers::getSuggestion(array_keys((array) $this), $key);


### PR DESCRIPTION
- BC break? no

## Description of the problem

While using Dibi with PhpStorm (the prevalent PHP IDE), I'm constantly being warned about using void where I should not.
![image](https://github.com/dg/dibi/assets/443067/1feb5824-eef8-4423-b2cc-703d993d86b0)

I'm pushed to either disable the inspection or suppress it for the given statement/block etc.
![image](https://github.com/dg/dibi/assets/443067/68649256-c72e-4d59-96a5-cf582863aed9)

But this inspection is useful and I do not wish to suppress it.


## Solution of the problem

Instead, we can just add `mixed` return type-hint to the magic `Row::__get` method to "confuse" PhpStorm. 
![image](https://github.com/dg/dibi/assets/443067/b3b27be9-8d9f-4fc5-9cf8-a26db891d8da)
We can do this, because we are actually using `Row` magically without type safety so there is no sacrifice to make. With `mixed` as the return value type, PS accepts it can not infer the type of the property and stops complaining.


We can then omit the suppressions
![image](https://github.com/dg/dibi/assets/443067/f912bcac-ee77-46e8-bb42-38de212bee0a)

and we end up with clean code:
![image](https://github.com/dg/dibi/assets/443067/e2ffbbf4-a511-42d4-a1e9-24d641b5fd04)

We are still warned that we acces the properties using "magic" (Property accessed via magic method).
