### PR TITLE
Add mixed type hint for magic properties (v4.x)

### DIFF
--- a/src/Dibi/Row.php
+++ b/src/Dibi/Row.php
@@ -49,6 +49,9 @@ class Row implements \ArrayAccess, \IteratorAggregate, \Countable
 	}
 
 
+	/**
+	 * @return mixed
+	 */
 	public function __get(string $key)
 	{
 		$hint = Helpers::getSuggestion(array_keys((array) $this), $key);


### PR DESCRIPTION
- BC break? no

Same as #443 for the v4.x branch.
