### PR TITLE
Fixed "Cannot use object of type stdClass as array"

### DIFF
--- a/src/Dibi/Bridges/Nette/DibiExtension3.php
+++ b/src/Dibi/Bridges/Nette/DibiExtension3.php
@@ -44,7 +44,7 @@ class DibiExtension3 extends Nette\DI\CompilerExtension
 			'lazy' => Expect::bool(false)->dynamic(),
 			'onConnect' => Expect::array()->dynamic(),
 			'substitutes' => Expect::arrayOf('string')->dynamic(),
-			'result' => Expect::structure([
+			'result' => Expect::array([
 				'normalize' => Expect::bool(true),
 				'formatDateTime' => Expect::string(),
 				'formatTimeInterval' => Expect::string(),


### PR DESCRIPTION
- bug fix
- BC break? no

v5.0.1
In Dibi\Connection.php: Helpers::alias($config, 'result|formatDate', 'resultDate');

Only with DibiExtension3. With DibiExtension22 it is ok.