### PR TITLE
Fixed TypeError: Dibi\Bridges\Tracy\Panel::getConnectionName(): Argum…

### DIFF
--- a/src/Dibi/Bridges/Tracy/Panel.php
+++ b/src/Dibi/Bridges/Tracy/Panel.php
@@ -151,8 +151,8 @@ class Panel implements Tracy\IBarPanel
 			#tracy-debug .tracy-DibiProfiler-source { color: #999 !important }
 			#tracy-debug tracy-DibiProfiler tr table { margin: 8px 0; max-height: 150px; overflow:auto } </style>
 			<h1>Queries:' . "\u{a0}" . count($this->events)
-				. ($totalTime === null ? '' : ", time:\u{a0}" . number_format($totalTime * 1000, 1, '.', "\u{202f}") . "\u{202f}ms") . ', '
-				. htmlspecialchars($this->getConnectionName($singleConnection)) . '</h1>
+				. ($totalTime === null ? '' : ", time:\u{a0}" . number_format($totalTime * 1000, 1, '.', "\u{202f}") . "\u{202f}ms") 
+				. ($singleConnection === null ? '' : ', ' . htmlspecialchars($this->getConnectionName($singleConnection))) . '</h1>
 			<div class="tracy-inner tracy-DibiProfiler">
 			<table class="tracy-sortable">
 				<tr><th>Time&nbsp;ms</th><th>SQL Statement</th><th>Rows</th>' . (!$singleConnection ? '<th>Connection</th>' : '') . '</tr>


### PR DESCRIPTION
- bug fix
- BC break? no

Fixed TypeError: Dibi\Bridges\Tracy\Panel::getConnectionName(): Argument #1 ($connection) must be of type Dibi\Connection, null given

$singleConnection is null when using multiple connections
