### PR TITLE
DibiExtension3: fixed schema, process 'result' recursively

### DIFF
--- a/src/Dibi/Bridges/Nette/DibiExtension3.php
+++ b/src/Dibi/Bridges/Nette/DibiExtension3.php
@@ -44,12 +44,12 @@ class DibiExtension3 extends Nette\DI\CompilerExtension
 			'lazy' => Expect::bool(false)->dynamic(),
 			'onConnect' => Expect::array()->dynamic(),
 			'substitutes' => Expect::arrayOf('string')->dynamic(),
-			'result' => Expect::array([
+			'result' => Expect::structure([
 				'normalize' => Expect::bool(true),
 				'formatDateTime' => Expect::string(),
 				'formatTimeInterval' => Expect::string(),
 				'formatJson' => Expect::string(),
-			]),
+			])->castTo('array'),
 		])->otherItems(Expect::type('mixed'))
 			->castTo('array');
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

[This fix](https://github.com/dg/dibi/commit/7c9ff39822ba692468cbc79f70f6385dc981bb8b) tried to fix the schema so that `$config['result']` is an array and not `stdClass`.

However, `Expect::array()` doesn't process the fields recursively, it just checks that the type is array and uses the argument as a default value. That leads to `Argument #2 ($normalize) must be of type bool, Nette\Schema\Elements\Type given`.

The correct way is to use `Expect::structure()` and then cast it to array (instead of `stdClass`).