### PR TITLE
Result::normalize() Fixed normalization of "-." numbers

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -466,7 +466,16 @@ class Result implements IDataSource
 					: $tmp;
 
 			} elseif ($type === Type::FLOAT) {
-				$value = ltrim((string) $value, '0');
+				$value = (string) $value;
+
+				$negative = false;
+				if ($value !== '' && $value[0] === '-') {
+					$value = substr($value, 1);
+					$negative = true;
+				}
+
+				$value = ltrim($value, '0');
+
 				$p = strpos($value, '.');
 				$e = strpos($value, 'e');
 				if ($p !== false && $e === false) {
@@ -477,6 +486,10 @@ class Result implements IDataSource
 
 				if ($value === '' || $value[0] === '.') {
 					$value = '0' . $value;
+				}
+
+				if ($negative) {
+					$value = '-' . $value;
 				}
 
 				$row[$key] = $value === str_replace(',', '.', (string) ($float = (float) $value))

--- a/tests/dibi/Result.normalize.phpt
+++ b/tests/dibi/Result.normalize.phpt
@@ -117,6 +117,42 @@ test('', function () {
 	Assert::same(['col' => '1.1e+10'], $result->test(['col' => '001.1e+10']));
 	Assert::notSame(['col' => '1.1e+1'], $result->test(['col' => '1.1e+10']));
 
+	// Same but negative
+	Assert::same(['col' => -0.0], $result->test(['col' => '-']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-.0']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-.1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0.0']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-0.1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0.000']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-0.100']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1.0']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-1.1']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1.000']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-1.100']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-001.000']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-001.100']));
+	Assert::same(['col' => -10.0], $result->test(['col' => '-10']));
+	Assert::same(['col' => -11.0], $result->test(['col' => '-11']));
+	Assert::same(['col' => -10.0], $result->test(['col' => '-0010']));
+	Assert::same(['col' => -11.0], $result->test(['col' => '-0011']));
+	Assert::same(['col' => '-0.00000000000000000001'], $result->test(['col' => '-0.00000000000000000001']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-12345678901234567890']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-012345678901234567890']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-12345678901234567890.000']));
+	Assert::same(['col' => '-12345678901234567890.1'], $result->test(['col' => '-012345678901234567890.100']));
+
+	Assert::same(['col' => -0.0], $result->test(['col' => -0]));
+	Assert::same(['col' => -0.0], $result->test(['col' => -0.0]));
+	Assert::same(['col' => -1.0], $result->test(['col' => -1]));
+	Assert::same(['col' => -1.0], $result->test(['col' => -1.0]));
+
+	Assert::same(['col' => '-1.1e+10'], $result->test(['col' => '-1.1e+10']));
+	Assert::same(['col' => '-1.1e-10'], $result->test(['col' => '-1.1e-10']));
+	Assert::same(['col' => '-1.1e+10'], $result->test(['col' => '-001.1e+10']));
+	Assert::notSame(['col' => '-1.1e+1'], $result->test(['col' => '-1.1e+10']));
+
 	setlocale(LC_ALL, 'de_DE@euro', 'de_DE', 'deu_deu');
 	Assert::same(['col' => 0.0], $result->test(['col' => '']));
 	Assert::same(['col' => 0.0], $result->test(['col' => '0']));
@@ -147,6 +183,38 @@ test('', function () {
 	Assert::same(['col' => 0.0], $result->test(['col' => 0.0]));
 	Assert::same(['col' => 1.0], $result->test(['col' => 1]));
 	Assert::same(['col' => 1.0], $result->test(['col' => 1.0]));
+
+	// Same but negative
+	Assert::same(['col' => -0.0], $result->test(['col' => '-']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-.0']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-.1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0.0']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-0.1']));
+	Assert::same(['col' => -0.0], $result->test(['col' => '-0.000']));
+	Assert::same(['col' => -0.1], $result->test(['col' => '-0.100']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1.0']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-1.1']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-1.000']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-1.100']));
+	Assert::same(['col' => -1.0], $result->test(['col' => '-001.000']));
+	Assert::same(['col' => -1.1], $result->test(['col' => '-001.100']));
+	Assert::same(['col' => -10.0], $result->test(['col' => '-10']));
+	Assert::same(['col' => -11.0], $result->test(['col' => '-11']));
+	Assert::same(['col' => -10.0], $result->test(['col' => '-0010']));
+	Assert::same(['col' => -11.0], $result->test(['col' => '-0011']));
+	Assert::same(['col' => '-0.00000000000000000001'], $result->test(['col' => '-0.00000000000000000001']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-12345678901234567890']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-012345678901234567890']));
+	Assert::same(['col' => '-12345678901234567890'], $result->test(['col' => '-12345678901234567890.000']));
+	Assert::same(['col' => '-12345678901234567890.1'], $result->test(['col' => '-012345678901234567890.100']));
+
+	Assert::same(['col' => -0.0], $result->test(['col' => -0]));
+	Assert::same(['col' => -0.0], $result->test(['col' => -0.0]));
+	Assert::same(['col' => -1.0], $result->test(['col' => -1]));
+	Assert::same(['col' => -1.0], $result->test(['col' => -1.0]));
+
 	setlocale(LC_NUMERIC, 'C');
 });
 


### PR DESCRIPTION
- bug fix
- BC break? no

I updated [Result::normalize()](https://github.com/typekcz/dibi/blob/7c9ff39822ba692468cbc79f70f6385dc981bb8b/src/Dibi/Result.php#L468) so that it can handle float normalization of negative numbers better.

More specifically numbers between -1 and 0 are returned from Oracle driver without 0 before decimal separator. For example `-.1` can be returned by Oracle, but fails in Result::normalize().

I added test cases for negative floats which all passed.