### PR TITLE
Fix numeric column formatting

### DIFF
--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -7,7 +7,7 @@ jobs:
         name: Nette Code Checker
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0
@@ -21,7 +21,7 @@ jobs:
         name: Nette Coding Standard
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
         name: PHPStan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
                     --health-retries=5
                     -e MYSQL_ROOT_PASSWORD=root
                     -e MYSQL_DATABASE=dibi_test
-                    --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
             postgres96:
                 image: postgres:9.6
@@ -89,7 +88,7 @@ jobs:
                     --health-retries 5
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}

--- a/src/Dibi/Translator.php
+++ b/src/Dibi/Translator.php
@@ -219,7 +219,7 @@ final class Translator
 
 				case 'a': // key=val, key=val, ...
 					foreach ($value as $k => $v) {
-						$pair = explode('%', $k, 2); // split into identifier & modifier
+						$pair = explode('%', (string) $k, 2); // split into identifier & modifier
 						$vx[] = $this->identifiers->{$pair[0]} . '='
 							. $this->formatValue($v, $pair[1] ?? (is_array($v) ? 'ex!' : null));
 					}


### PR DESCRIPTION
- bug fix
- BC break? no

We have some numeric columns in database for which Dibi fails with TypeError `explode() expects parameter 2 to be string, int given`.
I have fixed the case `a` that failed in our code, but it seems the same issue might be in cases `v` and `m` as well. I don't quite understand Dibi internals so I am unable to verify if it's a real problem in these cases.
The issue happens with code like `$connection->update('table', [10 => 'foo'])>where('id = %i', 1)->execute();`
If you could also backport the fix to the v4.2 branch, it would be welcome.
Thank you

![image](https://github.com/dg/dibi/assets/20974277/3e345a6f-db3c-4003-9ca1-97f03ab6917c)
